### PR TITLE
Support repeatedly inserting at the same position.

### DIFF
--- a/src/MagicString/index.js
+++ b/src/MagicString/index.js
@@ -164,7 +164,14 @@ MagicString.prototype = {
 		} else if ( index === this.original.length ) {
 			this.append( content );
 		} else {
-			this.replace( index, index, content );
+			var mapped = this.locate(index);
+
+			if ( mapped === null ) {
+				throw new Error( 'Cannot insert at replaced character index: ' + index );
+			}
+
+			this.str = this.str.substr( 0, mapped ) + content + this.str.substr( mapped );
+			adjust( this.mappings, index, this.mappings.length, content.length );
 		}
 
 		return this;
@@ -218,6 +225,13 @@ MagicString.prototype = {
 
 		if ( firstChar === null || lastChar === null ) {
 			throw new Error( 'Cannot replace the same content twice' );
+		}
+
+		if ( firstChar > lastChar + 1 ) {
+			throw new Error(
+				'BUG! First character mapped to a position after the last character: ' +
+				'[' + start + ', ' + end + '] -> [' + firstChar + ', ' + ( lastChar + 1 ) + ']'
+			);
 		}
 
 		this.str = this.str.substr( 0, firstChar ) + content + this.str.substring( lastChar + 1 );

--- a/test/index.js
+++ b/test/index.js
@@ -203,6 +203,12 @@ describe( 'MagicString', function () {
 			var s = new MagicString( 'abcdefghijkl' );
 			assert.strictEqual( s.insert( 0, 'a' ), s );
 		});
+
+		it( 'should insert repeatedly at the same position correctly', function () {
+			var s = new MagicString( 'ab' );
+			assert.equal( s.insert(1, '1').toString(), 'a1b' );
+			assert.equal( s.insert(1, '2').toString(), 'a12b' );
+		});
 	});
 
 	describe( 'locate', function () {


### PR DESCRIPTION
It seems that inserting at the same position multiple times can cause parts of the string to duplicate. The example in this commit is given `ab` and inserting `1` between `a` and `b`, followed by inserting `2` at the same position, yields `a121b` instead of the expected `a21b`.