### PR TITLE
Ensure inserting at position 0 is consistent with non-zero positions.

### DIFF
--- a/src/MagicString/index.js
+++ b/src/MagicString/index.js
@@ -173,9 +173,7 @@ MagicString.prototype = {
 			throw new TypeError( 'inserted content must be a string' );
 		}
 
-		if ( index === 0 ) {
-			this.prepend( content );
-		} else if ( index === this.original.length ) {
+		if ( index === this.original.length ) {
 			this.append( content );
 		} else {
 			var mapped = this.locate(index);

--- a/test/index.js
+++ b/test/index.js
@@ -272,6 +272,12 @@ describe( 'MagicString', function () {
 			assert.equal( s.insert(1, '2').toString(), 'a12b' );
 		});
 
+		it( 'should insert repeatedly at the beginning correctly', function () {
+			var s = new MagicString( 'ab' );
+			assert.equal( s.insert(0, '1').toString(), '1ab' );
+			assert.equal( s.insert(0, '2').toString(), '12ab' );
+		});
+
 		it( 'should throw when given non-string content', function () {
 			var s = new MagicString( '' );
 			assert.throws(
@@ -423,8 +429,8 @@ describe( 'MagicString', function () {
 			s.prepend( 'xyz' );
 			assert.equal( s.toString(), 'xyzabcdefghijkl' );
 
-			s.prepend( 'xyz' );
-			assert.equal( s.toString(), 'xyzxyzabcdefghijkl' );
+			s.prepend( '123' );
+			assert.equal( s.toString(), '123xyzabcdefghijkl' );
 		});
 
 		it( 'should return this', function () {


### PR DESCRIPTION
When inserting at non-zero positions the string is placed after any previous strings that would have been placed at that position. Before this commit, inserting at position 0 was treated specially, deferring to the `prepend` operation. This commit changes the behavior of inserts at 0 to match inserts at any other position. If the old behavior is desired, `prepend` should be called directly.

For context, this is an issue for `decaffeinate` because, given this CoffeeScript:

```coffeescript
a = 1
b = c = 2
```

I would like the final output to be this:

```js
var c;
var a = 1;
var b = c = 2;
```

However, what's actually being output is this:

```js
var var c;
a = 1;
var b = c = 2;
```

decaffeinate inserts `var c;\n` at 0 first because it wants that to be above any other statements. It then later inserts `var ` also at 0 (right before `a`), expecting it to appear *after* the previously-inserted variable declaration. That isn't happening, but with this patch it does.