### PR TITLE
Revert "simplify trim methods"

### DIFF
--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -181,11 +181,11 @@ MagicString.prototype = {
 	},
 
 	// get current location of character in original string
-	locate () {
+	locate ( character ) {
 		throw new Error( 'magicString.locate is deprecated' );
 	},
 
-	locateOrigin () {
+	locateOrigin ( character ) {
 		throw new Error( 'magicString.locateOrigin is deprecated' );
 	},
 
@@ -290,6 +290,8 @@ MagicString.prototype = {
 
 		let result = '';
 
+		// TODO handle moves
+
 		for ( let i = 0; i < this.chunks.length; i += 1 ) {
 			const chunk = this.chunks[i];
 
@@ -352,18 +354,36 @@ MagicString.prototype = {
 		this.outro = this.outro.replace( rx, '' );
 		if ( this.outro.length ) return this;
 
-		do {
-			let lastChunk = this.chunks[ this.chunks.length - 1 ];
-			if ( rx.test( lastChunk.content ) ) {
-				lastChunk.edit( lastChunk.content.replace( rx, '' ) );
+		let charIndex = this.original.length;
+		let i = this.chunks.length;
+
+		while ( i-- ) {
+			const chunk = this.chunks[i];
+
+			if ( charIndex > chunk.end ) {
+				const slice = this.original.slice( chunk.end, charIndex );
+
+				const match = rx.exec( slice );
+				if ( match ) {
+					this.chunk( charIndex - match[0].length, charIndex, '' );
+				}
+
+				if ( !match || match[0].length < slice.length ) {
+					// there is non-whitespace after the chunk
+					return this;
+				}
 			}
 
-			if ( lastChunk.content.length || this.chunks.length === 1 ) {
-				break;
-			} else {
-				this.chunks.pop();
-			}
-		} while ( true );
+			chunk.content = chunk.content.replace( rx, '' );
+			if ( chunk.content ) return this;
+
+			charIndex = chunk.start;
+		}
+
+		const slice = this.original.slice( 0, charIndex );
+
+		const match = rx.exec( slice );
+		if ( match ) this.chunk( charIndex - match[0].length, charIndex, '' );
 
 		return this;
 	},
@@ -374,19 +394,34 @@ MagicString.prototype = {
 		this.intro = this.intro.replace( rx, '' );
 		if ( this.intro.length ) return this;
 
-		do {
-			let firstChunk = this.chunks[0];
-			if ( rx.test( firstChunk.content ) ) {
-				firstChunk.edit( firstChunk.content.replace( rx, '' ) );
+		let charIndex = 0;
+
+		for ( let i = 0; i < this.chunks.length; i += 1 ) {
+			const chunk = this.chunks[i];
+
+			if ( charIndex < chunk.start ) {
+				const slice = this.original.slice( charIndex, chunk.start );
+
+				const match = rx.exec( slice );
+				if ( match ) this.chunk( charIndex, charIndex + match[0].length, '' );
+
+				if ( !match || match[0].length < slice.length ) {
+					// there is non-whitespace before the chunk
+					return this;
+				}
 			}
 
-			if ( firstChunk.content.length || this.chunks.length === 1 ) {
-				break;
-			} else {
-				this.chunks.shift();
-			}
-		} while ( true );
+			chunk.content = chunk.content.replace( rx, '' );
+			if ( chunk.content ) return this;
+
+			charIndex = chunk.end;
+		}
+
+		const slice = this.original.slice( charIndex, this.original.length );
+
+		const match = rx.exec( slice );
+		if ( match ) this.chunk( charIndex, charIndex + match[0].length, '' );
 
 		return this;
 	}
-};
+}


### PR DESCRIPTION
This reverts commit 7532328a5dbb216376e545f89a6afe4f07cff1b5.

I discovered that this was causing problems after attempting to update rollup-plugin-commonjs to use the latest of all its dependencies, including magic-string. Updating from v0.10.0 to v0.11.1 produced the following error:

```
  1) rollup-plugin-commonjs generates a sourcemap:
     AssertionError: null == 'samples/sourcemap/main.js'
      at test.js:72:11
      at tryCatch (node_modules/rollup/dist/rollup.js:400:12)
      at invokeCallback (node_modules/rollup/dist/rollup.js:412:13)
      at publish (node_modules/rollup/dist/rollup.js:383:7)
      at flush (node_modules/rollup/dist/rollup.js:127:5)
```

I noticed that the source map differed between the different versions of magic-string:

```
# magic-string 0.10.0

'use strict';

function __commonjs(fn, module) { return module = { exports: {} }, fn(module, module.exports), module.exports; }

var require$$0 = 42;

var main = __commonjs(function (module) {
var foo = require$$0;
console.log( foo );
});

var main$1 = (main && typeof main === 'object' && 'default' in main ? main['default'] : main);

module.exports = main$1;
{ version: 3,
  file: 'bundle.js',
  sources: [ 'samples/sourcemap/foo.js', 'samples/sourcemap/main.js' ],
  sourcesContent: 
   [ 'export default 42;\n',
     'var foo = require( \'./foo\' );\nconsole.log( foo );\n' ],
  names: [],
  mappings: ';;;;iBAAe,EAAE,CAAC;;;ACAlB,IAAI,GAAG,GAAG,UAAkB,CAAC;AAC7B,OAAO,CAAC,GAAG,EAAE,GAAG,EAAE,CAAC;;;;;' }


# magic-string 0.11.1

'use strict';

function __commonjs(fn, module) { return module = { exports: {} }, fn(module, module.exports), module.exports; }

var require$$0 = 42;

var main = __commonjs(function (module) {
var foo = require$$0;
console.log( foo );
});

var main$1 = (main && typeof main === 'object' && 'default' in main ? main['default'] : main);

module.exports = main$1;
{ version: 3,
  file: 'bundle.js',
  sources: [ 'samples/sourcemap/foo.js', 'samples/sourcemap/main.js' ],
  sourcesContent: 
   [ 'export default 42;\n',
     'var foo = require( \'./foo\' );\nconsole.log( foo );\n' ],
  names: [],
  mappings: ';;;;iBAAe,EAAE,CAAC;;;ACAlB,IAAI,GAAG,GAAG,UAAkB;;;;;;' }
```

It appears the source map in v0.11.1 is a truncated version of the other one. I determined that this commit was the bad one by using `git bisect` and `npm link` to run the `rollup-plugin-commonjs` tests with each revision, using `git bisect skip` on a few commits in magic-string that failed to pass its own tests. After reverting the bad commit on top of the current master the tests for rollup-plugin-commonjs began to work again. I don't have enough context on magic-string to fix the underlying cause, but you probably do, @Rich-Harris. Let me know if you need more information!