### PR TITLE
Make options optional for Bundle.prototype.generateMap.

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -79,6 +79,8 @@ Bundle.prototype = {
 	},
 
 	generateMap ( options ) {
+		options = options || {};
+
 		let offsets = {};
 
 		let names = [];


### PR DESCRIPTION
It's optional for MagicString.prototype.generateMap. This seems like a logical symmetry.