### PR TITLE
Change overwrite and remove to remove interior inserts

### DIFF
--- a/src/Chunk.js
+++ b/src/Chunk.js
@@ -56,6 +56,8 @@ Chunk.prototype = {
 
 	edit ( content, storeName ) {
 		this.content = content;
+		this.intro = '';
+		this.outro = '';
 		this.storeName = storeName;
 
 		this.edited = true;

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -308,17 +308,13 @@ MagicString.prototype = {
 			first.edit( content, storeName );
 
 			if ( first !== last ) {
-				first.outro = '';
-
 				let chunk = first.next;
 				while ( chunk !== last ) {
 					chunk.edit( '', false );
-					chunk.intro = chunk.outro = '';
 					chunk = chunk.next;
 				}
 
 				chunk.edit( '', false );
-				chunk.intro = '';
 			}
 		}
 

--- a/test/index.js
+++ b/test/index.js
@@ -698,7 +698,7 @@ describe( 'MagicString', function () {
 			var s = new MagicString( 'abcdefghijkl' );
 
 			s.remove( 0, 6 );
-			s.insertRight( 6, 'DEF' );
+			s.insertLeft( 6, 'DEF' );
 			s.overwrite( 6, 9, 'GHI' );
 			assert.equal( s.toString(), 'DEFGHIjkl' );
 		});
@@ -742,6 +742,17 @@ describe( 'MagicString', function () {
 				TypeError
 			);
 		});
+
+		it ( 'replaces interior inserts', function() {
+			var s = new MagicString( 'abcdefghijkl' );
+
+			s.insertLeft( 1, '&' );
+			s.insertRight( 1, '^' );
+			s.insertLeft( 3, '!' );
+			s.insertRight( 3, '?' );
+			s.overwrite( 1, 3, '...' );
+			assert.equal( s.toString(), 'a&...?defghijkl' );
+		})
 	});
 
 	describe( 'prepend', function () {
@@ -829,6 +840,17 @@ describe( 'MagicString', function () {
 			s.insertRight( 4, ')' );
 			s.remove( 2, 4 );
 			assert.equal( s.toString(), '(ab);' );
+		});
+
+		it( 'should remove interior inserts', function () {
+			var s = new MagicString( 'abc;' );
+
+			s.insertLeft( 1, '[' );
+			s.insertRight( 1, '(' );
+			s.insertLeft( 2, ')' );
+			s.insertRight( 2, ']' );
+			s.remove( 1, 2 );
+			assert.equal( s.toString(), 'a[]c;' );
 		});
 
 		it( 'should provide a useful error when illegal removals are attempted', function () {


### PR DESCRIPTION
This changes the `overwrite` and `remove` behavior to be consistent with `move`
and `slice`: the specified range includes any `insertRight`s on the left side
and any `insertLeft`s on the right side.

The code change ended up actually making the code simpler: `Chunk.edit` now
overwrites all chunk content, including the intro and outro, so the `overwrite`
code doesn't need to be careful about clearing the intro and outro for specific
chunks.

This fixes https://github.com/decaffeinate/decaffeinate/issues/269 . See my
comment in that bug for an explanation of what was going wrong, and why this
case is important.

In addition to this passing all of the magic-string tests, I also ran all of the
decaffeinate tests with this change and they all pass. So at least with the
decaffeinate project, the code wasn't depending on the previous behavior.