### PR TITLE
optimisation - remove empty chunks when overwriting

### DIFF
--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -330,15 +330,15 @@ MagicString.prototype = {
 		if ( first ) {
 			first.edit( content, storeName );
 
-			if ( first !== last ) {
-				let chunk = first.next;
-				while ( chunk !== last ) {
-					chunk.edit( '', false );
-					chunk = chunk.next;
-				}
-
-				chunk.edit( '', false );
+			if ( last ) {
+				first.next = last.next;
+			} else {
+				first.next = null;
+				this.lastChunk = first;
 			}
+
+			first.original = this.original.slice( start, end );
+			first.end = end;
 		}
 
 		else {


### PR DESCRIPTION
This collapses any obsolete chunks into one following `overwrite` or `remove` – i.e. instead of the edited chunk containing the overwrite followed by N empty chunks, it links the edited chunk directly to the next one. Linked lists FTW