### PR TITLE
Update types to better match reality.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module "magic-string" {
     clone(): Bundle;
     generateMap(options?: Partial<SourceMapOptions>): SourceMap;
     getIndentString(): string;
-    indent(indentStr: string): Bundle;
+    indent(indentStr?: string): Bundle;
     prepend(str: string): Bundle;
     toString(): string;
     trimLines(): string;
@@ -36,13 +36,15 @@ declare module "magic-string" {
     trimEnd(charType: string): Bundle;
   }
 
+  export type ExclusionRange = [ number, number ];
+
   export interface MagicStringOptions {
     filename: string,
-    indentExclusionRanges: any; // TODO
+    indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
   }
 
   export interface IndentOptions {
-    exclude: any; // TODO
+    exclude: ExclusionRange | Array<ExclusionRange>;
     indentStart: boolean;
   }
 
@@ -58,11 +60,11 @@ declare module "magic-string" {
     appendLeft(index: number, content: string): MagicString;
     appendRight(index: number, content: string): MagicString;
     clone(): MagicString;
-    generateMap(options?: Partial<SourceMapOptions>);
+    generateMap(options?: Partial<SourceMapOptions>): SourceMap;
     getIndentString(): string;
 
-    indent(options?): MagicString;
-    indent(indentStr: string, options: IndentOptions): MagicString;
+    indent(options?: IndentOptions): MagicString;
+    indent(indentStr?: string, options?: IndentOptions): MagicString;
 
     move(start: number, end: number, index: number): MagicString;
     overwrite(start: number, end: number, content: string, options?: boolean | OverwriteOptions): MagicString;

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -116,9 +116,7 @@ MagicString.prototype = {
 		cloned.lastChunk = clonedChunk;
 
 		if ( this.indentExclusionRanges ) {
-			cloned.indentExclusionRanges = typeof this.indentExclusionRanges[0] === 'number' ?
-				[ this.indentExclusionRanges[0], this.indentExclusionRanges[1] ] :
-				this.indentExclusionRanges.map( range => [ range.start, range.end ] );
+			cloned.indentExclusionRanges = this.indentExclusionRanges.slice();
 		}
 
 		Object.keys( this.sourcemapLocations ).forEach( loc => {

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -141,6 +141,19 @@ describe( 'MagicString', () => {
 			assert.deepEqual( source.indentExclusionRanges, clone.indentExclusionRanges );
 		});
 
+		it( 'should clone complex indentExclusionRanges', () => {
+			const array = [ [ 3, 6 ], [ 7, 9 ] ];
+			const source = new MagicString( 'abcdefghijkl', {
+				filename: 'foo.js',
+				indentExclusionRanges: array
+			});
+
+			const clone = source.clone();
+
+			assert.notStrictEqual( source.indentExclusionRanges, clone.indentExclusionRanges );
+			assert.deepEqual( source.indentExclusionRanges, clone.indentExclusionRanges );
+		});
+
 		it( 'should clone sourcemapLocations', () => {
 			const source = new MagicString( 'abcdefghijkl', {
 				filename: 'foo.js'


### PR DESCRIPTION
This also fixes an issue I discovered while figuring out what type `indentExclusionsRanges` was supposed to be. `MagicString#clone` does not appear to work when the object was constructed with a non-tuple. It seemed to expect an array of nodes – or something with `start` and `end` properties – but generated an array of tuples. Calling `#clone` multiple times no matter what the starting value would have resulted in an incorrect clone. I'm not 100% sure that I picked the right type, but this seemed the most consistent choice.