### PR TITLE
Correct SourceMap/Options TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,15 +7,18 @@ declare module "magic-string" {
   export interface SourceMapOptions {
     hires: boolean;
     file: string;
-    sources: string[];
-    sourcesContent: string;
+    source: string;
     includeContent: boolean;
-    names: string[];
-    mappings: string[];
   }
 
   class SourceMap {
-    constructor(properties: SourceMapOptions);
+    constructor(properties: SourceMap);
+    file: string;
+    sources: string[];
+    sourcesContent: string;
+    names: string[];
+    mappings: string[];
+
     toString(): string;
     toUrl(): string;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,8 +11,7 @@ declare module "magic-string" {
     includeContent: boolean;
   }
 
-  class SourceMap {
-    constructor(properties: SourceMap);
+  export interface SourceMap {
     file: string;
     sources: string[];
     sourcesContent: string;


### PR DESCRIPTION
`SourceMapOptions` does not include most of `SourceMap`'s keys.
`source` was also missing and added.
In addition, `SourceMap` is now an interface so that TypeScript won't let user code to use it with `new` (it's not being exported from main)