### PR TITLE
Don't use `declare module` for TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,80 +1,78 @@
-declare module "magic-string" {
-  export interface BundleOptions {
-    intro?: string;
-    separator?: string;
-  }
+export interface BundleOptions {
+  intro?: string;
+  separator?: string;
+}
 
-  export interface SourceMapOptions {
-    hires: boolean;
-    file: string;
-    source: string;
-    includeContent: boolean;
-  }
+export interface SourceMapOptions {
+  hires: boolean;
+  file: string;
+  source: string;
+  includeContent: boolean;
+}
 
-  export interface SourceMap {
-    file: string;
-    sources: string[];
-    sourcesContent: string;
-    names: string[];
-    mappings: string[];
+export interface SourceMap {
+  file: string;
+  sources: string[];
+  sourcesContent: string;
+  names: string[];
+  mappings: string[];
 
-    toString(): string;
-    toUrl(): string;
-  }
+  toString(): string;
+  toUrl(): string;
+}
 
-  export class Bundle {
-    constructor(options?: BundleOptions);
-    addSource(source: MagicString | { filename?: string, content: MagicString }): Bundle;
-    append(str: string, options: BundleOptions): Bundle;
-    clone(): Bundle;
-    generateMap(options?: Partial<SourceMapOptions>): SourceMap;
-    getIndentString(): string;
-    indent(indentStr?: string): Bundle;
-    prepend(str: string): Bundle;
-    toString(): string;
-    trimLines(): string;
-    trim(charType: string): string;
-    trimStart(charType: string): Bundle;
-    trimEnd(charType: string): Bundle;
-  }
+export class Bundle {
+  constructor(options?: BundleOptions);
+  addSource(source: MagicString | { filename?: string, content: MagicString }): Bundle;
+  append(str: string, options: BundleOptions): Bundle;
+  clone(): Bundle;
+  generateMap(options?: Partial<SourceMapOptions>): SourceMap;
+  getIndentString(): string;
+  indent(indentStr?: string): Bundle;
+  prepend(str: string): Bundle;
+  toString(): string;
+  trimLines(): string;
+  trim(charType: string): string;
+  trimStart(charType: string): Bundle;
+  trimEnd(charType: string): Bundle;
+}
 
-  export type ExclusionRange = [ number, number ];
+export type ExclusionRange = [ number, number ];
 
-  export interface MagicStringOptions {
-    filename: string,
-    indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
-  }
+export interface MagicStringOptions {
+  filename: string,
+  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
+}
 
-  export interface IndentOptions {
-    exclude: ExclusionRange | Array<ExclusionRange>;
-    indentStart: boolean;
-  }
+export interface IndentOptions {
+  exclude: ExclusionRange | Array<ExclusionRange>;
+  indentStart: boolean;
+}
 
-  export interface OverwriteOptions {
-    storeName: boolean;
-    contentOnly: boolean;
-  }
+export interface OverwriteOptions {
+  storeName: boolean;
+  contentOnly: boolean;
+}
 
-  export default class MagicString {
-    constructor(str: string, options?: MagicStringOptions);
-    addSourcemapLocation(char: number): void;
-    append(content: string): MagicString;
-    appendLeft(index: number, content: string): MagicString;
-    appendRight(index: number, content: string): MagicString;
-    clone(): MagicString;
-    generateMap(options?: Partial<SourceMapOptions>): SourceMap;
-    getIndentString(): string;
+export default class MagicString {
+  constructor(str: string, options?: MagicStringOptions);
+  addSourcemapLocation(char: number): void;
+  append(content: string): MagicString;
+  appendLeft(index: number, content: string): MagicString;
+  appendRight(index: number, content: string): MagicString;
+  clone(): MagicString;
+  generateMap(options?: Partial<SourceMapOptions>): SourceMap;
+  getIndentString(): string;
 
-    indent(options?: IndentOptions): MagicString;
-    indent(indentStr?: string, options?: IndentOptions): MagicString;
+  indent(options?: IndentOptions): MagicString;
+  indent(indentStr?: string, options?: IndentOptions): MagicString;
 
-    move(start: number, end: number, index: number): MagicString;
-    overwrite(start: number, end: number, content: string, options?: boolean | OverwriteOptions): MagicString;
-    prepend(content: string): MagicString;
-    prependLeft(index: number, content: string): MagicString;
-    prependRight(index: number, content: string): MagicString;
-    remove(start: number, end: number): MagicString;
-    slice(start: number, end: number): string;
-    snip(start: number, end: number): MagicString;
-  }
+  move(start: number, end: number, index: number): MagicString;
+  overwrite(start: number, end: number, content: string, options?: boolean | OverwriteOptions): MagicString;
+  prepend(content: string): MagicString;
+  prependLeft(index: number, content: string): MagicString;
+  prependRight(index: number, content: string): MagicString;
+  remove(start: number, end: number): MagicString;
+  slice(start: number, end: number): string;
+  snip(start: number, end: number): MagicString;
 }


### PR DESCRIPTION
As I understand things, the `declare module` TypeScript syntax creates a
globally-importable name and says that any import with that name maps to the
given type. This means it usually works for libraries, but breaks down when
you have multiple versions of the same library loaded, since they each redefine
the same global name. It's really meant for things like Node.js built-in
modules. Instead, `.d.ts` files in libraries should just do exports at the
top-level, and TypeScript allows different versions of the same library to
peacefully coexist in that case.

I ran into a dependency hell problem that I think was caused by this issue where
decaffeinate pulled in three different versions of magic-string that conflicted.
I was able to change the dependency tree so it's just one version, which works
in the near term, but this change should prevent that from happening again.