### PR TITLE
Add interfaces used by rollup

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,11 +11,12 @@ export interface SourceMapOptions {
 }
 
 export interface SourceMap {
+  version: string;
   file: string;
   sources: string[];
-  sourcesContent: string;
+  sourcesContent: string[];
   names: string[];
-  mappings: string[];
+  mappings: string;
 
   toString(): string;
   toUrl(): string;
@@ -32,8 +33,8 @@ export class Bundle {
   indent(indentStr?: string): Bundle;
   prepend(str: string): Bundle;
   toString(): string;
-  trimLines(): string;
-  trim(charType?: string): string;
+  trimLines(): Bundle;
+  trim(charType?: string): Bundle;
   trimStart(charType?: string): Bundle;
   trimEnd(charType?: string): Bundle;
 }
@@ -56,7 +57,7 @@ export interface OverwriteOptions {
 }
 
 export default class MagicString {
-  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
+  indentExclusionRanges: Array<ExclusionRange>;
 
   constructor(str: string, options?: MagicStringOptions);
   addSourcemapLocation(char: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,6 @@ export interface SourceMap {
 }
 
 export class Bundle {
-  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
   constructor(options?: BundleOptions);
   addSource(source: MagicString | { filename?: string, content: MagicString }): Bundle;
   append(str: string, options?: BundleOptions): Bundle;
@@ -31,6 +30,7 @@ export class Bundle {
   generateMap(options?: Partial<SourceMapOptions>): SourceMap;
   getIndentString(): string;
   indent(indentStr?: string): Bundle;
+  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
   prepend(str: string): Bundle;
   toString(): string;
   trimLines(): Bundle;
@@ -57,8 +57,6 @@ export interface OverwriteOptions {
 }
 
 export default class MagicString {
-  indentExclusionRanges: Array<ExclusionRange>;
-
   constructor(str: string, options?: MagicStringOptions);
   addSourcemapLocation(char: number): void;
   append(content: string): MagicString;
@@ -70,6 +68,7 @@ export default class MagicString {
 
   indent(options?: IndentOptions): MagicString;
   indent(indentStr?: string, options?: IndentOptions): MagicString;
+  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
 
   move(start: number, end: number, index: number): MagicString;
   overwrite(start: number, end: number, content: string, options?: boolean | OverwriteOptions): MagicString;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,9 +22,10 @@ export interface SourceMap {
 }
 
 export class Bundle {
+  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
   constructor(options?: BundleOptions);
   addSource(source: MagicString | { filename?: string, content: MagicString }): Bundle;
-  append(str: string, options: BundleOptions): Bundle;
+  append(str: string, options?: BundleOptions): Bundle;
   clone(): Bundle;
   generateMap(options?: Partial<SourceMapOptions>): SourceMap;
   getIndentString(): string;
@@ -32,9 +33,9 @@ export class Bundle {
   prepend(str: string): Bundle;
   toString(): string;
   trimLines(): string;
-  trim(charType: string): string;
-  trimStart(charType: string): Bundle;
-  trimEnd(charType: string): Bundle;
+  trim(charType?: string): string;
+  trimStart(charType?: string): Bundle;
+  trimEnd(charType?: string): Bundle;
 }
 
 export type ExclusionRange = [ number, number ];
@@ -55,6 +56,8 @@ export interface OverwriteOptions {
 }
 
 export default class MagicString {
+  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
+
   constructor(str: string, options?: MagicStringOptions);
   addSourcemapLocation(char: number): void;
   append(content: string): MagicString;


### PR DESCRIPTION
This adds missing interfaces used by Rollup in the progress of https://github.com/rollup/rollup/pull/1806.