### PR TITLE
Remove cruft, use sourcemap-codec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,6 +2410,11 @@
         "source-map": "0.5.6"
       }
     },
+    "sourcemap-codec": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
+      "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA=="
+    },
     "sparkles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
@@ -2461,12 +2466,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2493,6 +2492,12 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
@@ -2742,7 +2747,8 @@
     "vlq": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
+      "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
+      "dev": true
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "typings": "index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "vlq": "^0.2.2"
+    "sourcemap-codec": "^1.4.1"
   },
   "devDependencies": {
     "buble": "^0.15.2",

--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -1,14 +1,6 @@
-import { encode } from 'vlq';
+import { encode } from 'sourcemap-codec';
 
 export default function Mappings ( hires ) {
-	const offsets = {
-		generatedCodeColumn: 0,
-		sourceIndex: 0,
-		sourceCodeLine: 0,
-		sourceCodeColumn: 0,
-		sourceCodeName: 0
-	};
-
 	let generatedCodeLine = 0;
 	let generatedCodeColumn = 0;
 
@@ -19,13 +11,16 @@ export default function Mappings ( hires ) {
 
 	this.addEdit = ( sourceIndex, content, original, loc, nameIndex ) => {
 		if ( content.length ) {
-			rawSegments.push([
+			const segment = [
 				generatedCodeColumn,
 				sourceIndex,
 				loc.line,
-				loc.column,
-				nameIndex,
-			]);
+				loc.column
+			];
+			if ( nameIndex >= 0 ) {
+				segment.push( nameIndex );
+			}
+			rawSegments.push( segment );
 		} else if ( pending ) {
 			rawSegments.push( pending );
 		}
@@ -44,8 +39,7 @@ export default function Mappings ( hires ) {
 					generatedCodeColumn,
 					sourceIndex,
 					loc.line,
-					loc.column,
-					-1
+					loc.column
 				]);
 			}
 
@@ -68,8 +62,7 @@ export default function Mappings ( hires ) {
 			generatedCodeColumn,
 			sourceIndex,
 			loc.line,
-			loc.column,
-			-1,
+			loc.column
 		];
 	};
 
@@ -80,8 +73,10 @@ export default function Mappings ( hires ) {
 		const lastLine = lines.pop();
 
 		if ( lines.length ) {
-			generatedCodeLine += lines.length;
-			this.raw[ generatedCodeLine ] = rawSegments = [];
+			for ( let i = 0; i < lines.length; i++ ) {
+				generatedCodeLine++;
+				this.raw[generatedCodeLine] = rawSegments = [];
+			}
 			generatedCodeColumn = lastLine.length;
 		} else {
 			generatedCodeColumn += lastLine.length;
@@ -89,29 +84,6 @@ export default function Mappings ( hires ) {
 	};
 
 	this.encode = () => {
-		return this.raw.map( segments => {
-			let generatedCodeColumn = 0;
-
-			return segments.map( segment => {
-				const arr = [
-					segment[0] - generatedCodeColumn,
-					segment[1] - offsets.sourceIndex,
-					segment[2] - offsets.sourceCodeLine,
-					segment[3] - offsets.sourceCodeColumn
-				];
-
-				generatedCodeColumn = segment[0];
-				offsets.sourceIndex = segment[1];
-				offsets.sourceCodeLine = segment[2];
-				offsets.sourceCodeColumn = segment[3];
-
-				if ( ~segment[4] ) {
-					arr.push( segment[4] - offsets.sourceCodeName );
-					offsets.sourceCodeName = segment[4];
-				}
-
-				return encode( arr );
-			}).join( ',' );
-		}).join( ';' );
+		return encode(this.raw);
 	};
 }

--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -70,17 +70,16 @@ export default function Mappings ( hires ) {
 		if ( !str ) return;
 
 		const lines = str.split( '\n' );
-		const lastLine = lines.pop();
 
-		if ( lines.length ) {
-			for ( let i = 0; i < lines.length; i++ ) {
+		if ( lines.length > 1 ) {
+			for ( let i = 0; i < lines.length - 1; i++ ) {
 				generatedCodeLine++;
 				this.raw[generatedCodeLine] = rawSegments = [];
 			}
-			generatedCodeColumn = lastLine.length;
-		} else {
-			generatedCodeColumn += lastLine.length;
+			generatedCodeColumn = 0;
 		}
+
+		generatedCodeColumn += lines[lines.length - 1].length;
 	};
 
 	this.encode = () => {


### PR DESCRIPTION
Removes custom mappings encoding code in favor of the `sourcemap-codec` module (which also just got a faster version). Should make `generateMap` about 20-25% faster. cc @Rich-Harris @alangpierce 