### PR TITLE
Add generateDecodedMap and expose SourceMap class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,17 @@ export interface SourceMapOptions {
   includeContent: boolean;
 }
 
-export interface SourceMap {
+export interface DecodedSourceMap {
+  file: string;
+  sources: string[];
+  sourcesContent: string[];
+  names: string[];
+  mappings: number[][][];
+}
+
+export class SourceMap {
+  constructor(properties: DecodedSourceMap);
+
   version: string;
   file: string;
   sources: string[];
@@ -28,6 +38,7 @@ export class Bundle {
   append(str: string, options?: BundleOptions): Bundle;
   clone(): Bundle;
   generateMap(options?: Partial<SourceMapOptions>): SourceMap;
+  generateDecodedMap(options?: Partial<SourceMapOptions>): DecodedSourceMap;
   getIndentString(): string;
   indent(indentStr?: string): Bundle;
   indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
@@ -64,6 +75,7 @@ export default class MagicString {
   appendRight(index: number, content: string): MagicString;
   clone(): MagicString;
   generateMap(options?: Partial<SourceMapOptions>): SourceMap;
+  generateDecodedMap(options?: Partial<SourceMapOptions>): DecodedSourceMap;
   getIndentString(): string;
 
   indent(options?: IndentOptions): MagicString;

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -80,7 +80,7 @@ Bundle.prototype = {
 		return bundle;
 	},
 
-	generateMap ( options = {} ) {
+	generateDecodedMap ( options = {} ) {
 		const names = [];
 		this.sources.forEach( source => {
 			Object.keys( source.content.storedNames ).forEach( name => {
@@ -114,7 +114,7 @@ Bundle.prototype = {
 
 				if ( source.filename ) {
 					if ( chunk.edited ) {
-						mappings.addEdit( sourceIndex, chunk.content, chunk.original, loc, chunk.storeName ? names.indexOf( chunk.original ) : -1 );
+						mappings.addEdit( sourceIndex, chunk.content, loc, chunk.storeName ? names.indexOf( chunk.original ) : -1 );
 					} else {
 						mappings.addUneditedChunk( sourceIndex, chunk, magicString.original, loc, magicString.sourcemapLocations );
 					}
@@ -132,7 +132,7 @@ Bundle.prototype = {
 			}
 		});
 
-		return new SourceMap({
+		return {
 			file: ( options.file ? options.file.split( /[\/\\]/ ).pop() : null ),
 			sources: this.uniqueSources.map( source => {
 				return options.file ? getRelativePath( options.file, source.filename ) : source.filename;
@@ -141,8 +141,12 @@ Bundle.prototype = {
 				return options.includeContent ? source.content : null;
 			}),
 			names,
-			mappings: mappings.encode()
-		});
+			mappings: mappings.raw
+		};
+	},
+
+	generateMap ( options ) {
+		return new SourceMap(this.generateDecodedMap( options ));
 	},
 
 	getIndentString () {

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ import MagicString from './MagicString.js';
 
 export default MagicString;
 export { default as Bundle } from './Bundle.js';
+export { default as SourceMap} from './utils/SourceMap.js';

--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -1,5 +1,3 @@
-import { encode } from 'sourcemap-codec';
-
 export default function Mappings ( hires ) {
 	let generatedCodeLine = 0;
 	let generatedCodeColumn = 0;
@@ -9,7 +7,7 @@ export default function Mappings ( hires ) {
 
 	let pending = null;
 
-	this.addEdit = ( sourceIndex, content, original, loc, nameIndex ) => {
+	this.addEdit = ( sourceIndex, content, loc, nameIndex ) => {
 		if ( content.length ) {
 			const segment = [
 				generatedCodeColumn,
@@ -80,9 +78,5 @@ export default function Mappings ( hires ) {
 		}
 
 		generatedCodeColumn += lines[lines.length - 1].length;
-	};
-
-	this.encode = () => {
-		return encode(this.raw);
 	};
 }

--- a/src/utils/SourceMap.js
+++ b/src/utils/SourceMap.js
@@ -1,4 +1,5 @@
 import btoa from './btoa.js';
+import { encode } from 'sourcemap-codec';
 
 export default function SourceMap ( properties ) {
 	this.version = 3;
@@ -7,7 +8,7 @@ export default function SourceMap ( properties ) {
 	this.sources        = properties.sources;
 	this.sourcesContent = properties.sourcesContent;
 	this.names          = properties.names;
-	this.mappings       = properties.mappings;
+	this.mappings       = encode(properties.mappings);
 }
 
 SourceMap.prototype = {


### PR DESCRIPTION
@Rich-Harris see https://github.com/rollup/rollup/issues/2061 for motivation behind this change. It will make Rollup source map generation almost 2x faster.

- Add `MagicString`/`MagicStringBundle` `generateDecodedMap` method, which returns a JSON representation of a source map (with array-form mappings).
- Expose `SourceMap` class that accepts this form and creates a spec-compliant source map object.
- Add corresponding TypeScript types.

P.S. Feel free to add me as a collaborator — I can triage some open issues/PRs.