### PR TITLE
Fix trim bug with intro/outro

### DIFF
--- a/src/Chunk.js
+++ b/src/Chunk.js
@@ -121,12 +121,12 @@ export default class Chunk {
 
 		if (trimmed.length) {
 			if (trimmed !== this.content) {
-				this.split(this.start + trimmed.length).edit('', false);
+				this.split(this.start + trimmed.length).edit('', undefined, true);
 			}
 			return true;
 
 		} else {
-			this.edit('', false);
+			this.edit('', undefined, true);
 
 			this.intro = this.intro.replace(rx, '');
 			if (this.intro.length) return true;
@@ -142,12 +142,12 @@ export default class Chunk {
 		if (trimmed.length) {
 			if (trimmed !== this.content) {
 				this.split(this.end - trimmed.length);
-				this.edit('', false);
+				this.edit('', undefined, true);
 			}
 			return true;
 
 		} else {
-			this.edit('', false);
+			this.edit('', undefined, true);
 
 			this.outro = this.outro.replace(rx, '');
 			if (this.outro.length) return true;

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -1162,6 +1162,12 @@ describe( 'MagicString', () => {
 			const s = new MagicString( '  abcdefghijkl  ' );
 			assert.strictEqual( s.trim(), s );
 		});
+
+		it( 'should support trimming chunks with intro and outro', () => {
+			const s = new MagicString( '    \n' );
+			s.appendRight(4, 'test');
+			assert.strictEqual( s.trim().toString(), 'test' );
+		});
 	});
 
 	describe( 'trimLines', () => {


### PR DESCRIPTION
This fixes a bug where the intro and outro were being removed on trimmed chunks.

This caused issues where `magicSting.appendRight('x').trim()` would remove the `'x'` part.