### PR TITLE
overwrite segments for removed code

### DIFF
--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -27,12 +27,20 @@ export default class Mappings {
 		let originalCharIndex = chunk.start;
 		let first = true;
 
+		let len = this.rawSegments.length;
 		while (originalCharIndex < chunk.end) {
 			if (this.hires || first || sourcemapLocations[originalCharIndex]) {
-				this.rawSegments.push([this.generatedCodeColumn, sourceIndex, loc.line, loc.column]);
+				if (len !== 0) {
+					const segment = this.rawSegments[len - 1];
+					if (segment[0] === this.generatedCodeColumn) {
+						len -= 1; // overwrite segments for removed code
+					}
+				}
+				this.rawSegments[len++] = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];
 			}
 
 			if (original[originalCharIndex] === '\n') {
+				len = 0;
 				loc.line += 1;
 				loc.column = 0;
 				this.generatedCodeLine += 1;


### PR DESCRIPTION
Removed ranges create two source map segments that refer to the same generated column. I consider this bloat if there isn't a good reason behind it. Generally, there shouldn't be segments for removed code (not including the segment for the characters after, whose source column is the removed range's end column).

What's your take on this, @mourner and/or @Rich-Harris?

Figured I should get feedback before writing any tests.