### PR TITLE
Addition types for index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,10 @@ export default class MagicString {
   remove(start: number, end: number): MagicString;
   slice(start: number, end: number): string;
   snip(start: number, end: number): MagicString;
-  trim(): MagicString;
+  trim(charType?: string): MagicString;
+  trimStart(charType?: string): MagicString;
+  trimEnd(charType?: string): MagicString;
+  trimLines(): MagicString;
 
   lastChar(): string;
   lastLine(): string;


### PR DESCRIPTION
MagicString.trim, .trimStart, .trimEnd, .trimLines were missing.

I happened to need these methods on the project using TypeScript I was working on.