### PR TITLE
Fix type of SourceMap.version

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface DecodedSourceMap {
 export class SourceMap {
   constructor(properties: DecodedSourceMap);
 
-  version: string;
+  version: number;
   file: string;
   sources: string[];
   sourcesContent: string[];


### PR DESCRIPTION
[`SourceMap.js`](https://github.com/Rich-Harris/magic-string/blob/v0.25.2/src/SourceMap.js#L14) sets `this.version = 3`, but the type definitions claimed that `version` is a string.

My guess is that the type definitions for `magic-string` were based on those of `source-map` version 0.6 (or lower), which [had an incorrect type](https://github.com/mozilla/source-map/blob/0.6.1/source-map.d.ts#L7) for `version`. `source-map` version 0.7 [has the correct type](https://github.com/mozilla/source-map/blob/0.7.3/source-map.d.ts#L16).