### PR TITLE
Export SourceMapSegment tuple types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,12 +10,17 @@ export interface SourceMapOptions {
   includeContent: boolean;
 }
 
+export type SourceMapSegment =
+  | [number]
+  | [number, number, number, number]
+  | [number, number, number, number, number];
+
 export interface DecodedSourceMap {
   file: string;
   sources: string[];
   sourcesContent: string[];
   names: string[];
-  mappings: number[][][];
+  mappings: SourceMapSegment[][];
 }
 
 export class SourceMap {


### PR DESCRIPTION
`SourceMapSegment`s aren't really `number[]` types, they're tuples of 1, 4, or 5 numbers.

See the discussion we're having at https://github.com/rollup/rollup/pull/2985#discussion_r300591076