### PR TITLE
Don't emit source mappings for removed strings.

### DIFF
--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -47,7 +47,9 @@ export default class Mappings {
 			first = false;
 		}
 
-		this.pending = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];
+		this.pending = sourceIndex > 0
+			? [this.generatedCodeColumn, sourceIndex, loc.line, loc.column]
+			: null;
 	}
 
 	advance(str) {

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -182,10 +182,10 @@ describe('MagicString', () => {
 			assert.equal(map.file, 'output.md');
 			assert.deepEqual(map.sources, ['input.md']);
 			assert.deepEqual(map.sourcesContent, ['abcdefghijkl']);
-			assert.equal(map.mappings, 'AAAA,CAAC,CAAC,CAAC,AAAM,CAAC,CAAC');
+			assert.equal(map.mappings, 'AAAA,CAAC,CAAC,CAAO,CAAC,CAAC');
 
-			assert.equal(map.toString(), '{"version":3,"file":"output.md","sources":["input.md"],"sourcesContent":["abcdefghijkl"],"names":[],"mappings":"AAAA,CAAC,CAAC,CAAC,AAAM,CAAC,CAAC"}');
-			assert.equal(map.toUrl(), 'data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3V0cHV0Lm1kIiwic291cmNlcyI6WyJpbnB1dC5tZCJdLCJzb3VyY2VzQ29udGVudCI6WyJhYmNkZWZnaGlqa2wiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQ0FBQyxDQUFDLENBQUMsQUFBTSxDQUFDLENBQUMifQ==');
+			assert.equal(map.toString(), '{"version":3,"file":"output.md","sources":["input.md"],"sourcesContent":["abcdefghijkl"],"names":[],"mappings":"AAAA,CAAC,CAAC,CAAO,CAAC,CAAC"}');
+			assert.equal(map.toUrl(), 'data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3V0cHV0Lm1kIiwic291cmNlcyI6WyJpbnB1dC5tZCJdLCJzb3VyY2VzQ29udGVudCI6WyJhYmNkZWZnaGlqa2wiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQ0FBQyxDQUFDLENBQU8sQ0FBQyxDQUFDIn0=');
 
 			const smc = new SourceMapConsumer(map);
 			let loc;
@@ -241,8 +241,8 @@ describe('MagicString', () => {
 			assert.deepEqual(map.sources, ['input.md']);
 			assert.deepEqual(map.sourcesContent, ['abcdefghijkl']);
 
-			assert.equal(map.toString(), '{"version":3,"file":"output.md","sources":["input.md"],"sourcesContent":["abcdefghijkl"],"names":[],"mappings":"AAAA,GAAG,GAAG,AAAG,CAAC"}');
-			assert.equal(map.toUrl(), 'data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3V0cHV0Lm1kIiwic291cmNlcyI6WyJpbnB1dC5tZCJdLCJzb3VyY2VzQ29udGVudCI6WyJhYmNkZWZnaGlqa2wiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsR0FBRyxHQUFHLEFBQUcsQ0FBQyJ9');
+			assert.equal(map.toString(), '{"version":3,"file":"output.md","sources":["input.md"],"sourcesContent":["abcdefghijkl"],"names":[],"mappings":"AAAA,GAAG,GAAM,CAAC"}');
+			assert.equal(map.toUrl(), 'data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3V0cHV0Lm1kIiwic291cmNlcyI6WyJpbnB1dC5tZCJdLCJzb3VyY2VzQ29udGVudCI6WyJhYmNkZWZnaGlqa2wiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsR0FBRyxHQUFNLENBQUMifQ==');
 
 			const smc = new SourceMapConsumer(map);
 			let loc;


### PR DESCRIPTION
Fixes #149

Also fixes two incorrect test results and the rollup issue:
rollup/rollup#3001