### PR TITLE
fix sourcemap of prepend when hire false

### DIFF
--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -38,13 +38,14 @@ export default class Mappings {
 				this.generatedCodeLine += 1;
 				this.raw[this.generatedCodeLine] = this.rawSegments = [];
 				this.generatedCodeColumn = 0;
+				first = true;
 			} else {
 				loc.column += 1;
 				this.generatedCodeColumn += 1;
+				first = false;
 			}
 
 			originalCharIndex += 1;
-			first = false;
 		}
 
 		this.pending = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -203,6 +203,18 @@ describe('MagicString', () => {
 			assert.equal(loc.column, 10);
 		});
 
+		it('should generate a correct sourcemap for prepend content when hires = false', () => {
+			const s = new MagicString('x\nq');
+
+			s.prepend('y\n');
+
+			const map = s.generateMap({
+				includeContent: true,
+			});
+
+			assert.equal(map.mappings,';AAAA;AACA');
+		});
+
 		it('should generate a correct sourcemap for indented content', () => {
 			const s = new MagicString('var answer = 42;\nconsole.log("the answer is %s", answer);');
 


### PR DESCRIPTION
when prepend, the generated map is not recognized by chrome/firefox: can not set break point on second line when there are multiple lines