### PR TITLE
Clones intro and outro of MagicString

### DIFF
--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -125,6 +125,9 @@ export default class MagicString {
 			cloned.sourcemapLocations[loc] = true;
 		});
 
+		cloned.intro = this.intro;
+		cloned.outro = this.outro;
+
 		return cloned;
 	}
 

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -165,6 +165,17 @@ describe('MagicString', () => {
 			assert.notStrictEqual(source.sourcemapLocations, clone.sourcemapLocations);
 			assert.deepEqual(source.sourcemapLocations, clone.sourcemapLocations);
 		});
+
+		it('should clone intro and outro', () => {
+			const source = new MagicString('defghi');
+
+			source.prepend('abc');
+			source.append('jkl');
+
+			const clone = source.clone();
+
+			assert.equal(source.toString(), clone.toString());
+		});
 	});
 
 	describe('generateMap', () => {


### PR DESCRIPTION
MagicString instances, when cloned would not inherit their intro and outro properties. Add test to ensure that a cloned MagicString with prefix and suffix will produce a generated string matching the original. Correctly clone `.intro` and `.outro` to get the expected behaviour.

Fixes #162.