### PR TITLE
export SourceMap in cjs/umd builds as well

### DIFF
--- a/src/index-legacy.js
+++ b/src/index-legacy.js
@@ -1,7 +1,9 @@
 import MagicString from './MagicString.js';
 import Bundle from './Bundle.js';
+import SourceMap from './SourceMap.js';
 
 MagicString.Bundle = Bundle;
+MagicString.SourceMap = SourceMap;
 MagicString.default = MagicString; // work around TypeScript bug https://github.com/Rich-Harris/magic-string/pull/121
 
 export default MagicString;


### PR DESCRIPTION
Currently SourceMap is exported only in ES module

Originally reported as https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=942045