### PR TITLE
feat: support a function for `includeContent` in Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,10 @@ bundle.toString()
 //   console.log( answer );
 // }());
 
-// options are as per `s.generateMap()` above
+// options are as per `s.generateMap()` above, except that `includeContent` can
+// also be a function of the shape `(source: { filename: string, content: string }) => boolean`,
+// letting you decide per-source whether to embed its content - for example, to omit
+// content for sources that can otherwise be loaded by the runtime, such as public http(s) urls
 const map = bundle.generateMap({
   file: 'bundle.js',
   includeContent: true,

--- a/README.md
+++ b/README.md
@@ -344,10 +344,7 @@ bundle.toString()
 //   console.log( answer );
 // }());
 
-// options are as per `s.generateMap()` above, except that `includeContent` can
-// also be a function of the shape `(source: { filename: string, content: string }) => boolean`,
-// letting you decide per-source whether to embed its content - for example, to omit
-// content for sources that can otherwise be loaded by the runtime, such as public http(s) urls
+// options are as per `s.generateMap()` above
 const map = bundle.generateMap({
   file: 'bundle.js',
   includeContent: true,

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -28,6 +28,21 @@ interface UniqueSource {
   content: string
 }
 
+export interface BundledSourceFileRecord {
+  filename: string
+  content: string
+}
+
+export interface BundleSourceMapOptions extends Omit<SourceMapOptions, 'includeContent'> {
+  /**
+   * Whether to include the original content of each source in the map's `sourcesContent` array.
+   * Can also be a function that receives the source's `filename` and `content` and returns
+   * whether to include it, allowing per-source control (for example, omitting content for
+   * sources that are otherwise loadable at runtime, such as public http(s) urls).
+   */
+  includeContent?: boolean | ((source: BundledSourceFileRecord) => boolean)
+}
+
 export interface DecodedSourceMapOrMissingContent extends Omit<DecodedSourceMap, 'sourcesContent'> {
   sourcesContent: Array<string | null>
 }
@@ -133,7 +148,7 @@ export default class Bundle {
     return bundle as this
   }
 
-  generateDecodedMap(options: SourceMapOptions = {}): DecodedSourceMapOrMissingContent {
+  generateDecodedMap(options: BundleSourceMapOptions = {}): DecodedSourceMapOrMissingContent {
     const names = []
     let x_google_ignoreList
     this.sources.forEach((source) => {
@@ -214,7 +229,11 @@ export default class Bundle {
         return options.file ? getRelativePath(options.file, source.filename) : source.filename
       }),
       sourcesContent: this.uniqueSources.map((source) => {
-        return options.includeContent ? source.content : null
+        const includeContent = typeof options.includeContent === 'function'
+          ? options.includeContent(source)
+          : options.includeContent
+
+        return includeContent ? source.content : null
       }),
       names,
       mappings: mappings.raw,
@@ -224,7 +243,7 @@ export default class Bundle {
   }
 
   generateMap(
-    options?: SourceMapOptions,
+    options?: BundleSourceMapOptions,
   ): Omit<SourceMap, 'sourcesContent'> & { sourcesContent: Array<string | null> } {
     return new SourceMap(this.generateDecodedMap(options)) as Omit<SourceMap, 'sourcesContent'> & {
       sourcesContent: Array<string | null>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import MagicStringError from './MagicStringError.ts'
 import SourceMap from './SourceMap.ts'
 
 export { Bundle, MagicString as default, MagicString, MagicStringError, SourceMap }
-export type { BundleOptions } from './Bundle.ts'
+export type { BundledSourceFileRecord, BundleOptions, BundleSourceMapOptions } from './Bundle.ts'
 export type {
   ExclusionRange,
   IndentOptions,

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -719,6 +719,32 @@ describe('bundle', () => {
         column: 16,
       })
     })
+
+    it('supports a function for includeContent', () => {
+      const b = new Bundle()
+
+      const files: Record<string, MagicString> = {
+        'one.js': new MagicString('function one () {}', { filename: 'one.js' }),
+        'two.js': new MagicString('function two () {}', { filename: 'two.js' }),
+      }
+
+      b.addSource(files['one.js'])
+      b.addSource(files['two.js'])
+
+      const map = b.generateMap({
+        file: 'output.js',
+        source: 'input.js',
+        includeContent(source) {
+          assert.ok(files[source.filename])
+          assert.equal(files[source.filename].original, source.content)
+
+          return source.filename === 'one.js'
+        },
+      })
+
+      assert.equal(map.sourcesContent[0], files['one.js'].original)
+      assert.equal(map.sourcesContent[1], null)
+    })
   })
 
   describe('indent', () => {


### PR DESCRIPTION
Suppose you have a `magic-string` built up from a variety of sources, some of which can be loaded by the runtime and some that can't. Those that can be loaded might be, for example, public http(s) urls. In this scenario, you might want to embed source content for those sources that _can't_ be loaded at runtime.