### PR TITLE
Types: Fix indentExclusionRanges marked as required, despite being optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export class Bundle {
   generateDecodedMap(options?: Partial<SourceMapOptions>): DecodedSourceMap;
   getIndentString(): string;
   indent(indentStr?: string): Bundle;
-  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
+  indentExclusionRanges?: ExclusionRange | Array<ExclusionRange>;
   prepend(str: string): Bundle;
   toString(): string;
   trimLines(): Bundle;


### PR DESCRIPTION
This PR updates the typings for the `options` object passed into the `MagicString` constructor. According to the source code `options.indentExclusionRanges` is optional, but the typings list it as [being required](https://github.com/Rich-Harris/magic-string/blob/389c1f1688b5f58db6589601f57b901a2aa43ce1/src/MagicString.js#L121-L123). This PR corrects that.