### PR TITLE
fix(types): make MagicStringOptions optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,8 @@ export class Bundle {
 export type ExclusionRange = [ number, number ];
 
 export interface MagicStringOptions {
-  filename: string,
-  indentExclusionRanges: ExclusionRange | Array<ExclusionRange>;
+  filename?: string,
+  indentExclusionRanges?: ExclusionRange | Array<ExclusionRange>;
 }
 
 export interface IndentOptions {


### PR DESCRIPTION
Looks based on usage that both of these properties are optional.

Currently, I can't provide an option with just `filename` without providing `indentExclusionRanges`.