### PR TITLE
Add feature: copy, like move

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   ],
   "scripts": {
     "test": "mocha",
-    "pretest": "npm run lint && npm run build",
+    "pretest": "npm run lint && npm run build -- --environment DEBUG",
     "format": "prettier --single-quote --print-width 100 --use-tabs --write src/*.js src/**/*.js",
     "build": "rollup -c",
     "prepare": "npm run build",
     "prepublishOnly": "rm -rf dist && npm test",
     "lint": "eslint src test",
-    "watch": "rollup -cw"
+    "watch": "rollup -cw --environment DEBUG"
   },
   "files": [
     "dist/*",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import replace from 'rollup-plugin-replace';
 const plugins = [
 	buble({ exclude: 'node_modules/**' }),
 	nodeResolve(),
-	replace({ DEBUG: false })
+	replace({ DEBUG: !!process.env.DEBUG })
 ];
 
 export default [

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -359,6 +359,9 @@ export default class MagicString {
 				lastDuped = nextDuped;
 			}
 		}
+		if (DEBUG) {
+			duplicates.forEach(dupe => dupe.isCopy = true);
+		}
 		const newFirst = duplicates[0];
 		const newLast = duplicates[duplicates.length - 1];
 

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -311,9 +311,9 @@ export default class MagicString {
 		if (newLeft) newLeft.next = first;
 		if (newRight) newRight.previous = last;
 
-		if (!first.previous) this.firstChunk = last.next;
+		if (!first.previous) this.firstChunk = oldRight;
 		if (!last.next) {
-			this.lastChunk = first.previous;
+			this.lastChunk = oldLeft;
 			this.lastChunk.next = null;
 		}
 
@@ -324,6 +324,54 @@ export default class MagicString {
 		if (!newRight) this.lastChunk = last;
 
 		if (DEBUG) this.stats.timeEnd('move');
+		return this;
+	}
+
+	copy(start, end, index) {
+		if (DEBUG) this.stats.time('copy');
+
+		this._split(start);
+		this._split(end);
+		this._split(index);
+
+		const first = this.byStart[start];
+		const last = this.byEnd[end];
+
+		const newRight = this.byStart[index];
+		if (!newRight && last === this.lastChunk) return this;
+		const newLeft = newRight ? newRight.previous : this.lastChunk;
+
+		const duplicates = [first.clone()];
+		if (first !== last) {
+			let lastOld = first;
+			let lastDuped = duplicates[duplicates.length - 1];
+			while (true) {
+				const nextOld = lastOld.next;
+				const nextDuped = nextOld.clone();
+
+				lastDuped.next = nextDuped;
+				nextDuped.previous = lastDuped;
+
+				duplicates.push(nextDuped);
+
+				if (nextOld === last) break;
+				lastOld = nextOld;
+				lastDuped = nextDuped;
+			}
+		}
+		const newFirst = duplicates[0];
+		const newLast = duplicates[duplicates.length - 1];
+
+		if (newLeft) newLeft.next = newFirst;
+		newFirst.previous = newLeft;
+
+		if (newRight) newRight.previous = newLast;
+		newLast.next = newRight || null;
+
+		if (!newLeft) this.firstChunk = newFirst;
+		if (!newRight) this.lastChunk = newLast;
+
+		if (DEBUG) this.stats.timeEnd('copy');
 		return this;
 	}
 

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -721,6 +721,102 @@ describe('MagicString', () => {
 		});
 	});
 
+	describe('copy', () => {
+		it('copies characters', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.copy(3, 6, 9);
+			assert.equal(s.toString(), 'abcDEFghiDEFjkl');
+		});
+
+		it('copies to the beginning', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.copy(3, 6, 0);
+			assert.equal(s.toString(), 'DEFabcDEFghijkl');
+		});
+
+		it('copies to the end', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.copy(3, 6, 12);
+			assert.equal(s.toString(), 'abcDEFghijklDEF');
+		});
+
+		it('allows pasting selection into itself', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.copy(3, 6, 4);
+			assert.equal(s.toString(), 'abcDDEFEFghijkl');
+		});
+
+		it('puts multiple insertions in the same place in the order they were inserted', () => {
+			const s = new MagicString('ABcDEfghijkl');
+
+			s.copy(3, 5, 9);
+			s.copy(0, 2, 9);
+			assert.equal(s.toString(), 'ABcDEfghiDEABjkl');
+		});
+
+		it('carries over append made beforehand at beginning of selection', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.appendRight(3, 'x');
+			s.copy(3, 6, 9);
+			assert.equal(s.toString(), 'abcxDEFghixDEFjkl');
+		});
+
+		it('carries over append made beforehand at end of selection', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.appendLeft(6, 'x');
+			s.copy(3, 6, 9);
+			assert.equal(s.toString(), 'abcDEFxghiDEFxjkl');
+		});
+
+		it('carries over overwrite made beforehand in middle of selection', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.overwrite(4, 5, 'xy');
+			s.copy(3, 6, 9);
+			assert.equal(s.toString(), 'abcDxyFghiDxyFjkl');
+		});
+
+		it('does not carry over changes made after copy', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.copy(3, 6, 9);
+			s.overwrite(4, 5, 'xy');
+			s.appendRight(4, 'a');
+			s.appendLeft(5, 'b');
+			assert.equal(s.toString(), 'abcDaxybFghiDEFjkl');
+		});
+
+		it('does not carry over changes next to the selection', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.appendRight(6, 'x');
+			s.overwrite(2, 3, 'foo');
+			s.appendLeft(3, 'y');
+			s.copy(3, 6, 9);
+			assert.equal(s.toString(), 'abfooyDEFxghiDEFjkl');
+		});
+
+		it('cannot insert into an overwritten area', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.overwrite(8, 10, 'foo');
+			assert.throws(() => s.copy(3, 6, 9), /Cannot split a chunk that has already been edited/);
+		});
+
+		it('cannot copy part of overwritten area', () => {
+			const s = new MagicString('abcDEFghijkl');
+
+			s.overwrite(2, 5, 'foo');
+			assert.throws(() => s.copy(3, 6, 9), /Cannot split a chunk that has already been edited/);
+		});
+	});
+
 	describe('overwrite', () => {
 		it('should replace characters', () => {
 			const s = new MagicString('abcdefghijkl');

--- a/test/utils/IntegrityCheckingMagicString.js
+++ b/test/utils/IntegrityCheckingMagicString.js
@@ -7,15 +7,17 @@ class IntegrityCheckingMagicString extends MagicString {
 		let chunk = this.firstChunk;
 		let numNodes = 0;
 		while (chunk) {
-			assert.strictEqual(this.byStart[chunk.start], chunk);
-			assert.strictEqual(this.byEnd[chunk.end], chunk);
-			assert.strictEqual(chunk.previous, prevChunk);
-			if (prevChunk) {
-				assert.strictEqual(prevChunk.next, chunk);
+			if (!chunk.isCopy) {
+				assert.strictEqual(this.byStart[chunk.start], chunk);
+				assert.strictEqual(this.byEnd[chunk.end], chunk);
+				assert.strictEqual(chunk.previous, prevChunk);
+				if (prevChunk) {
+					assert.strictEqual(prevChunk.next, chunk);
+				}
+				numNodes++;
 			}
 			prevChunk = chunk;
 			chunk = chunk.next;
-			numNodes++;
 		}
 		assert.strictEqual(prevChunk, this.lastChunk);
 		assert.strictEqual(this.lastChunk.next, null);


### PR DESCRIPTION
(I'm lazy, so description just copied from commits)
Just like move (from where the main idea is copied), but keeps the original
chunks in place.

The implementation currently suffers from one drawback - the new chunks
aren't added into the byStart/byEnd indexes - since these index by original
location, the index would now have to lead to 2 locations. So if you copy
first, then overwrite/append/prepend, the changes are only written in the
original location, not on the copied snippet. However, if you do anything
before copying, the changes are carried over.

---

Regarding the added test and changes in package.json:

In test/dev builds, DEBUG is replaced with true, which runs additional
code marking the 'duplicate' chunks created by .copy() with chunk.isCopy.

This is detected in integrity checker in tests - these chunks are,
as described in previous commit, not included in the indexes, which
isn't easy to solve, so these chunks are just excluded from the check.

In production code (verified with npm run publish), DEBUG is replaced
with false and the code becomes unreachable and is tree-shaked.

---

**Why I'm implementing this**

For `svelte-check` - the type-checking (the svelte2tsx step) around `svelte:component this={x} bind:this={y}` is simplified (well, pretty much non-existent), and the copy feature is required for implementing it correctly. I hope this could help other projects as well.

**Does the resulting source map work**

[I believe so](https://sokra.github.io/source-map-visualization/#base64,PHN2ZWx0ZWNvbXBvbmVudCB0aGlzPXtzaG93ID8gQSA6IG51bGx9IHtzaG91bGRFcXVhbCgoeCA9IGluc3RhbmNlb2Yoc2hvdyA/IEEgOiBudWxsKSkpfSAvPg==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZXhhbXBsZS5qcyIsInNvdXJjZXMiOltudWxsXSwic291cmNlc0NvbnRlbnQiOlsiPHN2ZWx0ZTpjb21wb25lbnQgdGhpcz17c2hvdyA/IEEgOiBudWxsfSBiaW5kOnRoaXM9e3h9IC8+Il0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLE9BQVEsZ0JBQWdCLGVBQWUsRUFBRSxjQUFXLGVBQTVCLGVBQTZCLElBQUMifQ==,PHN2ZWx0ZTpjb21wb25lbnQgdGhpcz17c2hvdyA/IEEgOiBudWxsfSBiaW5kOnRoaXM9e3h9IC8+)