### PR TITLE
Change contentOnly default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Moves the characters from `start` and `end` to `index`. Returns `this`.
 
 Replaces the characters from `start` to `end` with `content`. The same restrictions as `s.remove()` apply. Returns `this`.
 
-The fourth argument is optional. It can have a `storeName` property — if `true`, the original name will be stored for later inclusion in a sourcemap's `names` array — and a `contentOnly` property which determines whether only the content is overwritten, or anything that was appended/prepended to the range as well.
+The fourth argument is optional. It can have a `storeName` property — if `true`, the original name will be stored for later inclusion in a sourcemap's `names` array — and a `contentOnly` property which defaults to `true` and determines whether only the content is overwritten, or anything that was appended/prepended to the range as well.
 
 ### s.prepend( content )
 

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -361,7 +361,7 @@ export default class MagicString {
 			options = { storeName: true };
 		}
 		const storeName = options !== undefined ? options.storeName : false;
-		const contentOnly = options !== undefined ? options.contentOnly : false;
+		const contentOnly = options !== undefined ? options.contentOnly : true;
 
 		if (storeName) {
 			const original = this.original.slice(start, end);

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -767,11 +767,11 @@ describe('MagicString', () => {
 			assert.equal(s.toString(), 'DEFGHIjkl');
 		});
 
-		it('replaces zero-length inserts inside overwrite', () => {
+		it('replaces zero-length inserts inside overwrite with `contentOnly: false`', () => {
 			const s = new MagicString('abcdefghijkl');
 
 			s.appendLeft(6, 'XXX');
-			s.overwrite(3, 9, 'DEFGHI');
+			s.overwrite(3, 9, 'DEFGHI', { contentOnly: false });
 			assert.equal(s.toString(), 'abcDEFGHIjkl');
 		});
 
@@ -802,7 +802,18 @@ describe('MagicString', () => {
 			assert.throws(() => s.overwrite(0, 1, []), TypeError);
 		});
 
-		it('replaces interior inserts', () => {
+		it('replaces interior inserts with `contentOnly: false`', () => {
+			const s = new MagicString('abcdefghijkl');
+
+			s.appendLeft(1, '&');
+			s.prependRight(1, '^');
+			s.appendLeft(3, '!');
+			s.prependRight(3, '?');
+			s.overwrite(1, 3, '...', { contentOnly: false });
+			assert.equal(s.toString(), 'a&...?defghijkl');
+		});
+
+		it('preserves interior inserts', () => {
 			const s = new MagicString('abcdefghijkl');
 
 			s.appendLeft(1, '&');
@@ -810,17 +821,6 @@ describe('MagicString', () => {
 			s.appendLeft(3, '!');
 			s.prependRight(3, '?');
 			s.overwrite(1, 3, '...');
-			assert.equal(s.toString(), 'a&...?defghijkl');
-		});
-
-		it('preserves interior inserts with `contentOnly: true`', () => {
-			const s = new MagicString('abcdefghijkl');
-
-			s.appendLeft(1, '&');
-			s.prependRight(1, '^');
-			s.appendLeft(3, '!');
-			s.prependRight(3, '?');
-			s.overwrite(1, 3, '...', { contentOnly: true });
 			assert.equal(s.toString(), 'a&^...!?defghijkl');
 		});
 
@@ -846,11 +846,11 @@ describe('MagicString', () => {
 			assert.throws(() => s.overwrite(4, 11, 'XX'), /Cannot overwrite across a split point/);
 		});
 
-		it('allows later insertions at the end', () => {
+		it('allows later insertions at the end with `contentOnly: false`', () => {
 			const s = new MagicString('abcdefg');
 
 			s.appendLeft(4, '(');
-			s.overwrite(2, 7, '');
+			s.overwrite(2, 7, '', { contentOnly: false });
 			s.appendLeft(7, 'h');
 			assert.equal(s.toString(), 'abh');
 		});


### PR DESCRIPTION
This would fix https://github.com/vitejs/vite/issues/7365. 

To quote @dummdidumm on that issue:

>The `overwrite` call removes all prepends/appends that were done on the start/end position if you don't pass in the `{ contentOnly: true }` option as forth argument. I never came across a case where I would want the default behavior, so I'm always setting that option. 