### PR TITLE
perf: use `@jridgewell/sourcemap-codec`

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -8,7 +8,7 @@ console.log(`node ${process.version}\n`);
 
 function runWithInstance(name, inputs, func, setup) {
 	const ss = [];
-	return new Benchmark(
+	new Benchmark(
 		name,
 		{
 			setup: () => {
@@ -39,17 +39,17 @@ async function bench() {
 		)
 	);
 
-		new Benchmark('construct', {
-			fn: () => {
-				for (const input of inputs) {
-					new MagicString(input);
-				}
+	new Benchmark('construct', {
+		fn: () => {
+			for (const input of inputs) {
+				new MagicString(input);
 			}
-		}).on('complete', (event) => {
-			console.log(String(event.target));
-		}).on('error', (event) => {
-			console.error(event.target.error);
-		}).run()
+		}
+	}).on('complete', (event) => {
+		console.log(String(event.target));
+	}).on('error', (event) => {
+		console.error(event.target.error);
+	}).run();
 
 	runWithInstance('append', inputs, s => {
 		s.append(';"append";');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.26.2",
       "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -120,6 +120,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "node_modules/@jsdevtools/ez-spawn": {
       "version": "3.0.4",
@@ -3394,7 +3399,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -3964,6 +3970,11 @@
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "@jsdevtools/ez-spawn": {
       "version": "3.0.4",
@@ -6420,7 +6431,8 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "bench": "npm run build && node benchmark/index.mjs",
     "watch": "rollup -cw"
   },
-  "dependencies": {
-    "sourcemap-codec": "^1.4.8"
-  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-replace": "^4.0.0",
@@ -60,5 +57,8 @@
   },
   "engines": {
     "node": ">=12"
+  },
+  "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.4.13"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default [
 	/* esm */
 	{
 		input: 'src/index.js',
-		external: ['sourcemap-codec'],
+		external: ['@jridgewell/sourcemap-codec'],
 		plugins,
 		output: {
 			file: 'dist/magic-string.es.mjs',
@@ -23,7 +23,7 @@ export default [
 	/* cjs */
 	{
 		input: 'src/index-legacy.js',
-		external: ['sourcemap-codec'],
+		external: ['@jridgewell/sourcemap-codec'],
 		plugins,
 		output: {
 			file: 'dist/magic-string.cjs.js',

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -1,4 +1,4 @@
-import { encode } from 'sourcemap-codec';
+import { encode } from '@jridgewell/sourcemap-codec';
 
 let btoa = () => {
 	throw new Error('Unsupported environment: `window.btoa` or `Buffer` should be supported.');


### PR DESCRIPTION
[`@jridgewell/sourcemap-codec` has better performance and memory footprint than `sourcemap-codec`](https://github.com/jridgewell/sourcemap-codec#benchmarks).

This PR replaces `sourcemap-codec` with `@jridgewell/sourcemap-codec`.

**before**
```
node v16.16.0

generateMap (no edit) x 1,664 ops/sec ±0.62% (92 runs sampled)
generateMap (edit) x 1,651 ops/sec ±0.74% (92 runs sampled)
```
**after**
```
node v16.16.0

generateMap (no edit) x 1,981 ops/sec ±0.52% (93 runs sampled)
generateMap (edit) x 1,901 ops/sec ±0.56% (93 runs sampled)
```
