### PR TITLE
perf: avoiding use of Object.defineProperty in Chunk constructor

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -75,6 +75,13 @@ async function bench() {
 	}, s => {
 		s.replace(/replacement/g, 'replacement\nReplacement');
 	});
+
+	const size = 1000000;
+	runWithInstance('overwrite', ['a'.repeat(size)], s => {
+		for (let i = 1; i < size; i+=2) {
+			s.overwrite(i, i+1, 'b');
+		}
+	});
 }
 
 bench();

--- a/src/Chunk.js
+++ b/src/Chunk.js
@@ -11,11 +11,16 @@ export default class Chunk {
 		this.storeName = false;
 		this.edited = false;
 
-		// we make these non-enumerable, for sanity while debugging
-		Object.defineProperties(this, {
-			previous: { writable: true, value: null },
-			next: { writable: true, value: null },
-		});
+		if (DEBUG) {
+			// we make these non-enumerable, for sanity while debugging
+			Object.defineProperties(this, {
+				previous: { writable: true, value: null },
+				next: { writable: true, value: null },
+			});
+		} else {
+			this.previous = null;
+			this.next = null;
+		}
 	}
 
 	appendLeft(content) {


### PR DESCRIPTION
As described here https://humanwhocodes.com/blog/2015/11/performance-implication-object-defineproperty/
`Object.defineProperty` does add some overhead.

This can become significant when a lot of splitting is involved.

This PR restrict the usage of `Object.defineProperty` in DEBUG only.

A benchmark using overwrite has been added, an show significant improvement.
other benchmarks have been improved too.

before
```
construct x 78,561 ops/sec ±0.50% (93 runs sampled)
append x 5,732,848 ops/sec ±5.76% (44 runs sampled)
indent x 2,386 ops/sec ±1.50% (89 runs sampled)
generateMap (no edit) x 1,283 ops/sec ±1.86% (89 runs sampled)
generateMap (edit) x 1,346 ops/sec ±0.76% (93 runs sampled)
generateDecodedMap (no edit) x 1,604 ops/sec ±1.07% (92 runs sampled)
generateDecodedMap (edit) x 1,574 ops/sec ±1.12% (90 runs sampled)
overwrite x 0.67 ops/sec ±2.38% (6 runs sampled)
```


after
```
construct x 95,813 ops/sec ±0.51% (95 runs sampled)
append x 5,992,517 ops/sec ±5.10% (62 runs sampled)
indent x 2,624 ops/sec ±1.64% (89 runs sampled)
generateMap (no edit) x 1,331 ops/sec ±1.40% (91 runs sampled)
generateMap (edit) x 1,355 ops/sec ±0.62% (94 runs sampled)
generateDecodedMap (no edit) x 1,664 ops/sec ±0.40% (95 runs sampled)
generateDecodedMap (edit) x 1,650 ops/sec ±0.83% (96 runs sampled)
overwrite x 2.31 ops/sec ±3.67% (10 runs sampled)
```


