### PR TITLE
Put `types` first in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/magic-string.es.mjs",
-      "require": "./dist/magic-string.cjs.js",
-      "types": "./index.d.ts"
+      "require": "./dist/magic-string.cjs.js"
     }
   },
   "files": [


### PR DESCRIPTION
The TypeScript docs say `types` must come first: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing