### PR TITLE
feat(x_google_ignoreList): initial support for ignore lists

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ export interface DecodedSourceMap {
   sourcesContent: (string | null)[];
   names: string[];
   mappings: SourceMapSegment[][];
+  x_google_ignoreList?: number[];
 }
 
 export class SourceMap {
@@ -49,6 +50,7 @@ export class SourceMap {
   sourcesContent: (string | null)[];
   names: string[];
   mappings: string;
+  x_google_ignoreList?: number[];
 
   /**
    * Returns the equivalent of `JSON.stringify(map)`

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -22,6 +22,9 @@ export default class SourceMap {
 		this.sourcesContent = properties.sourcesContent;
 		this.names = properties.names;
 		this.mappings = encode(properties.mappings);
+		if (typeof properties.x_google_ignoreList !== 'undefined') {
+			this.x_google_ignoreList = properties.x_google_ignoreList;
+		}
 	}
 
 	toString() {

--- a/test/MagicString.SourceMap.js
+++ b/test/MagicString.SourceMap.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const MagicString = require('../');
+
+require('source-map-support').install();
+
+describe('MagicString.SourceMap', () => {
+	describe('options', () => {
+		it('preserves ignore list information', () => {
+			const map = new MagicString.SourceMap({
+				file: 'foo.min.js',
+				sources: ['foo.js'],
+				sourcesContent: ['42'],
+				names: [],
+				mappings: [[0, 0]],
+				x_google_ignoreList: [0]
+			});
+
+			assert.deepEqual(map.x_google_ignoreList, [0]);
+		});
+	});
+
+	describe('toString', () => {
+		it('serializes ignore list information', () => {
+			const map = new MagicString.SourceMap({
+				file: 'foo.min.js',
+				sources: ['foo.js'],
+				sourcesContent: ['42'],
+				names: [],
+				mappings: [[0, 0]],
+				x_google_ignoreList: [0]
+			});
+
+			assert.equal(map.toString(), '{"version":3,"file":"foo.min.js","sources":["foo.js"],"sourcesContent":["42"],"names":[],"mappings":"AAAAA,AAAAA","x_google_ignoreList":[0]}');
+		});
+	});
+});


### PR DESCRIPTION
This patch introduces support for the `x_google_ignoreList` field to the `SourceMap` class. This extension was added to the Source Map Revision 3 Proposal[^1] to allow build tools to provide hints to debuggers (e.g. browser DevTools) about which files contain library or framework, and should thus be ignored by default for the purpose of stepping, break on exceptions, and the like[^2].

With this change it's possible for consumers of magic-string's `SourceMap` class to thread through and serialize the newly added `x_google_ignoreList` field (for example this is needed for rollup to support `x_google_ignoreList`).

In a follow up change, we will also add support to the `Bundle` class to mark certain sources as ignore listed.

Ref: https://github.com/Rich-Harris/magic-string/issues/241

[^1]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k
[^2]: https://developer.chrome.com/blog/devtools-better-angular-debugging/