### PR TITLE
fix: `null` is invalid for `sources` and `file`

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -144,7 +144,7 @@ export default class Bundle {
 		});
 
 		return {
-			file: options.file ? options.file.split(/[/\\]/).pop() : null,
+			file: options.file ? options.file.split(/[/\\]/).pop() : undefined,
 			sources: this.uniqueSources.map((source) => {
 				return options.file ? getRelativePath(options.file, source.filename) : source.filename;
 			}),

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -163,9 +163,9 @@ export default class MagicString {
 		});
 
 		return {
-			file: options.file ? options.file.split(/[/\\]/).pop() : null,
-			sources: [options.source ? getRelativePath(options.file || '', options.source) : null],
-			sourcesContent: options.includeContent ? [this.original] : [null],
+			file: options.file ? options.file.split(/[/\\]/).pop() : undefined,
+			sources: [options.source ? getRelativePath(options.file || '', options.source) : (options.file || '')],
+			sourcesContent: options.includeContent ? [this.original] : undefined,
 			names,
 			mappings: mappings.raw,
 		};


### PR DESCRIPTION
This fixes `generateDecodedMap()` to avoid putting `null` into the `sources` array (which is supposed to contain only strings), and also don't assign `null` to the `file` field (which can be either a string or absent - indicated by `undefined`).