### PR TITLE
feat: add the ability to ignore-list sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ const s = new MagicString(someCode, {
   // these options will be used if you later call `bundle.addSource( s )` - see below
   filename: 'foo.js',
   indentExclusionRanges: [/*...*/],
-	ignoreList: true
+  // market source as ignore in DevTools, see below #Bundling
+  ignoreList: false
 });
 ```
 
@@ -255,9 +256,9 @@ bundle.addSource({
 // to not step into this code and also don't show the source files depending
 // on user preferences.
 bundle.addSource({
-	filename: 'some-3rdparty-library.js',
-	content: new MagicString('function myLib(){}'),
-	ignoreList: false
+  filename: 'some-3rdparty-library.js',
+  content: new MagicString('function myLib(){}'),
+  ignoreList: false // <--
 })
 
 // Advanced: a source can include an `indentExclusionRanges` property

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ You can pass an options argument:
 
 ```js
 const s = new MagicString(someCode, {
-  // both these options will be used if you later
-  // call `bundle.addSource( s )` - see below
+  // these options will be used if you later call `bundle.addSource( s )` - see below
   filename: 'foo.js',
-  indentExclusionRanges: [/*...*/]
+  indentExclusionRanges: [/*...*/],
+	ignoreList: true
 });
 ```
 
@@ -250,6 +250,15 @@ bundle.addSource({
   filename: 'bar.js',
   content: new MagicString('console.log( answer )')
 });
+
+// Sources can be marked as ignore-listed, which provides a hint to debuggers
+// to not step into this code and also don't show the source files depending
+// on user preferences.
+bundle.addSource({
+	filename: 'some-3rdparty-library.js',
+	content: new MagicString('function myLib(){}'),
+	ignoreList: false
+})
 
 // Advanced: a source can include an `indentExclusionRanges` property
 // alongside `filename` and `content`. This will be passed to `s.indent()`

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,17 @@ export class SourceMap {
 
 export class Bundle {
   constructor(options?: BundleOptions);
-  addSource(source: MagicString | { filename?: string, content: MagicString }): Bundle;
+  /**
+   * Adds the specified source to the bundle, which can either be a `MagicString` object directly,
+   * or an options object that holds a magic string `content` property and optionally provides
+   * a `filename` for the source within the bundle, as well as an optional `ignoreList` hint
+   * (which defaults to `false`). The `filename` is used when constructing the source map for the
+   * bundle, to identify this `source` in the source map's `sources` field. The `ignoreList` hint
+   * is used to populate the `x_google_ignoreList` extension field in the source map, which is a
+   * mechanism for tools to signal to debuggers that certain sources should be ignored by default
+   * (depending on user preferences).
+   */
+  addSource(source: MagicString | { filename?: string, content: MagicString, ignoreList?: boolean }): Bundle;
   append(str: string, options?: BundleOptions): Bundle;
   clone(): Bundle;
   generateMap(options?: SourceMapOptions): SourceMap;
@@ -117,7 +127,7 @@ export default class MagicString {
   append(content: string): MagicString;
   /**
    * Appends the specified content at the index in the original string.
-   * If a range *ending* with index is subsequently moved, the insert will be moved with it. 
+   * If a range *ending* with index is subsequently moved, the insert will be moved with it.
    * See also `s.prependLeft(...)`.
    */
   appendLeft(index: number, content: string): MagicString;
@@ -162,13 +172,13 @@ export default class MagicString {
    */
   move(start: number, end: number, index: number): MagicString;
   /**
-   * Replaces the characters from `start` to `end` with `content`, along with the appended/prepended content in 
+   * Replaces the characters from `start` to `end` with `content`, along with the appended/prepended content in
    * that range. The same restrictions as `s.remove()` apply.
    *
    * The fourth argument is optional. It can have a storeName property — if true, the original name will be stored
    * for later inclusion in a sourcemap's names array — and a contentOnly property which determines whether only
    * the content is overwritten, or anything that was appended/prepended to the range as well.
-   * 
+   *
    * It may be preferred to use `s.update(...)` instead if you wish to avoid overwriting the appended/prepended content.
    */
   overwrite(start: number, end: number, content: string, options?: boolean | OverwriteOptions): MagicString;
@@ -181,7 +191,7 @@ export default class MagicString {
    */
   update(start: number, end: number, content: string, options?: boolean | UpdateOptions): MagicString;
   /**
-   * Prepends the string with the specified content. 
+   * Prepends the string with the specified content.
    */
   prepend(content: string): MagicString;
   /**

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -31,7 +31,7 @@ export default class Bundle {
 			);
 		}
 
-		['filename', 'indentExclusionRanges', 'separator'].forEach((option) => {
+		['filename', 'ignoreList', 'indentExclusionRanges', 'separator'].forEach((option) => {
 			if (!hasOwnProp.call(source, option)) source[option] = source.content[option];
 		});
 
@@ -84,6 +84,7 @@ export default class Bundle {
 
 	generateDecodedMap(options = {}) {
 		const names = [];
+		let x_google_ignoreList = undefined;
 		this.sources.forEach((source) => {
 			Object.keys(source.content.storedNames).forEach((name) => {
 				if (!~names.indexOf(name)) names.push(name);
@@ -141,6 +142,13 @@ export default class Bundle {
 			if (magicString.outro) {
 				mappings.advance(magicString.outro);
 			}
+
+			if (source.ignoreList && sourceIndex !== -1) {
+				if (x_google_ignoreList === undefined) {
+					x_google_ignoreList = [];
+				}
+				x_google_ignoreList.push(sourceIndex);
+			}
 		});
 
 		return {
@@ -153,6 +161,7 @@ export default class Bundle {
 			}),
 			names,
 			mappings: mappings.raw,
+			x_google_ignoreList,
 		};
 	}
 

--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -34,6 +34,7 @@ export default class MagicString {
 			sourcemapLocations: { writable: true, value: new BitSet() },
 			storedNames: { writable: true, value: {} },
 			indentStr: { writable: true, value: undefined },
+			ignoreList: { writable: true, value: options.ignoreList },
 		});
 
 		if (DEBUG) {
@@ -168,6 +169,7 @@ export default class MagicString {
 			sourcesContent: options.includeContent ? [this.original] : undefined,
 			names,
 			mappings: mappings.raw,
+			x_google_ignoreList: this.ignoreList ? [sourceIndex] : undefined
 		};
 	}
 

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -13,6 +13,12 @@ describe('MagicString', () => {
 
 			assert.equal(s.filename, 'foo.js');
 		});
+
+		it('stores ignore-list hint', () => {
+			const s = new MagicString('abc', { ignoreList: true });
+
+			assert.equal(s.ignoreList, true);
+		});
 	});
 
 	describe('append', () => {
@@ -417,6 +423,16 @@ describe('MagicString', () => {
 
 			const map = s.generateMap();
 			assert.equal(map.mappings, 'IAAA');
+		});
+
+		it('generates x_google_ignoreList', () => {
+			const s = new MagicString('function foo(){}', {
+				ignoreList: true
+		  });
+
+			const map = s.generateMap({ source: 'foo.js' });
+			assert.deepEqual(map.sources, ['foo.js']);
+			assert.deepEqual(map.x_google_ignoreList, [0]);
 		});
 	});
 


### PR DESCRIPTION
This adds the ability to mark sources emitted into a source map as ignore-listed, which provides a hint that debuggers can utilize when dealing with these sources[^1].

The `ignoreList` option can be passed to a `MagicString` now, and will be considered when generating a source map for it. In addition that bit will also be considered when the `MagicString` is added as source to a `Bundle` (with the possibility to override the value via a parameter to `addSource`). The `x_google_ignoreList` field in the source map will only be emitted if at least one of its sources was explicitly marked with `ignoreList: true`. Otherwise - and primarily for backwards compatibility with the existing ecosystem - no `x_google_ignoreList` field is emitted.

Fixes Rich-Harris/magic-string#241

[^1]: https://developer.chrome.com/blog/devtools-better-angular-debugging

cc @victorporof