### PR TITLE
chore: add Node 18 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [12.x, 14.x, 16.x]
+        node_version: [12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
@@ -35,7 +35,7 @@ jobs:
         run: npm i
 
       - name: Lint
-        if: ${{ matrix.node_version != '12.x' }}
+        if: ${{ matrix.node_version == '14.x' }}
         run: npm run lint
 
       - name: Test


### PR DESCRIPTION
We probably only need to run `lint` on a single Node version

Note to self: Node 10 dropped earlier simply because `mocha` doesn't run on Node 10: https://github.com/Rich-Harris/magic-string/pull/204