### PR TITLE
feat: hires boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Generates a [version 3 sourcemap](https://docs.google.com/document/d/1U1RGAehQwR
 * `file` - the filename where you plan to write the sourcemap
 * `source` - the filename of the file containing the original source
 * `includeContent` - whether to include the original content in the map's `sourcesContent` array
-* `hires` - whether the mapping should be high-resolution. Hi-res mappings map every single character, meaning (for example) your devtools will always be able to pinpoint the exact location of function calls and so on. With lo-res mappings, devtools may only be able to identify the correct line - but they're quicker to generate and less bulky. If sourcemap locations have been specified with `s.addSourcemapLocation()`, they will be used here.
+* `hires` - whether the mapping should be high-resolution. Hi-res mappings map every single character, meaning (for example) your devtools will always be able to pinpoint the exact location of function calls and so on. With lo-res mappings, devtools may only be able to identify the correct line - but they're quicker to generate and less bulky. You can also set `"boundary"` to generate a semi-hi-res mappings segmented per word boundary instead of per character, suitable for string semantics that are separated by words. If sourcemap locations have been specified with `s.addSourcemapLocation()`, they will be used here.
 
 The returned sourcemap has two (non-enumerable) methods attached for convenience:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,9 +10,11 @@ export interface SourceMapOptions {
    * be able to pinpoint the exact location of function calls and so on.
    * With lo-res mappings, devtools may only be able to identify the correct
    * line - but they're quicker to generate and less bulky.
+   * You can also set `"boundary"` to generate a semi-hi-res mappings segmented per word boundary
+   * instead of per character, suitable for string semantics that are separated by words.
    * If sourcemap locations have been specified with s.addSourceMapLocation(), they will be used here.
    */
-  hires?: boolean;
+  hires?: boolean | 'boundary';
   /**
    * The filename where you plan to write the sourcemap.
    */

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -434,6 +434,41 @@ describe('MagicString', () => {
 			assert.deepEqual(map.sources, ['foo.js']);
 			assert.deepEqual(map.x_google_ignoreList, [0]);
 		});
+
+		it('generates segments per word boundary with hires "boundary"', () => {
+			const s = new MagicString('function foo(){ console.log("bar") }');
+
+			// rename bar to hello
+			s.overwrite(29, 32, 'hello');
+
+			const map = s.generateMap({
+				file: 'output.js',
+				source: 'input.js',
+				includeContent: true,
+				hires: 'boundary'
+			});
+			
+			assert.equal(map.mappings, 'AAAA,QAAQ,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,KAAG,CAAC,CAAC,CAAC');
+
+			const smc = new SourceMapConsumer(map);
+			let loc;
+
+			loc = smc.originalPositionFor({ line: 1, column: 3 });
+			assert.equal(loc.line, 1);
+			assert.equal(loc.column, 0);
+
+			loc = smc.originalPositionFor({ line: 1, column: 11 });
+			assert.equal(loc.line, 1);
+			assert.equal(loc.column, 9);
+
+			loc = smc.originalPositionFor({ line: 1, column: 29 });
+			assert.equal(loc.line, 1);
+			assert.equal(loc.column, 29);
+
+			loc = smc.originalPositionFor({ line: 1, column: 35 });
+			assert.equal(loc.line, 1);
+			assert.equal(loc.column, 33);
+		});
 	});
 
 	describe('getIndentString', () => {


### PR DESCRIPTION
`hires: 'boundary'` generates a segment for each word boundary, instead of for each character. Which should help:

- Reduce sourcemap size
- Easier to find original position in mappings
- Faster sourcemap merging

From twitter idea: https://twitter.com/dummdidumm_/status/1674102437890621454

[Example sourcemap visualization](https://evanw.github.io/source-map-visualization/#NDAzAGZ1bmN0aW9uIGZvbygpeyBjb25zb2xlLmxvZygiaGVsbG8iKSB9Ci8vIyBzb3VyY2VNYXBwaW5nVVJMPWRhdGE6YXBwbGljYXRpb24vanNvbjtjaGFyc2V0PXV0Zi04O2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKbWFXeGxJam9pYjNWMGNIVjBMbXB6SWl3aWMyOTFjbU5sY3lJNld5SnBibkIxZEM1cWN5SmRMQ0p6YjNWeVkyVnpRMjl1ZEdWdWRDSTZXeUptZFc1amRHbHZiaUJtYjI4b0tYc2dZMjl1YzI5c1pTNXNiMmNvWENKaVlYSmNJaWtnZlNKZExDSnVZVzFsY3lJNlcxMHNJbTFoY0hCcGJtZHpJam9pUVVGQlFTeFJRVUZSTEVOQlFVTXNSMEZCUnl4RFFVRkRMRU5CUVVNc1EwRkJReXhEUVVGRExFOUJRVThzUTBGQlF5eEhRVUZITEVOQlFVTXNRMEZCUXl4TFFVRkhMRU5CUVVNc1EwRkJReXhEUVVGREluMD0yMjQAeyJ2ZXJzaW9uIjozLCJmaWxlIjoib3V0cHV0LmpzIiwic291cmNlcyI6WyJpbnB1dC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBmb28oKXsgY29uc29sZS5sb2coXCJiYXJcIikgfSJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxRQUFRLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQyxLQUFHLENBQUMsQ0FBQyxDQUFDIn0=)
