### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,14 @@
   "repository": "https://github.com/rich-harris/magic-string",
   "license": "MIT",
   "author": "Rich Harris",
+  "type": "commonjs",
   "main": "./dist/magic-string.cjs.js",
-  "module": "./dist/magic-string.es.mjs",
-  "jsnext:main": "./dist/magic-string.es.mjs",
   "types": "./dist/magic-string.cjs.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/magic-string.es.mjs",
-      "require": "./dist/magic-string.cjs.js"
+      "default": "./dist/magic-string.cjs.js"
     }
   },
   "files": [


### PR DESCRIPTION
cleaning up a couple of issues from https://publint.dev/magic-string@0.30.10

`module` and `jsnext:main` will be ignored since `exports` is present