### PR TITLE
perf: skip line break mappings

### DIFF
--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -54,27 +54,6 @@ export default class Mappings {
 		let charInHiresBoundary = false;
 
 		while (originalCharIndex < chunk.end) {
-			if (this.hires || first || sourcemapLocations.has(originalCharIndex)) {
-				const segment = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];
-
-				if (this.hires === 'boundary') {
-					// in hires "boundary", group segments per word boundary than per char
-					if (wordRegex.test(original[originalCharIndex])) {
-						// for first char in the boundary found, start the boundary by pushing a segment
-						if (!charInHiresBoundary) {
-							this.rawSegments.push(segment);
-							charInHiresBoundary = true;
-						}
-					} else {
-						// for non-word char, end the boundary by pushing a segment
-						this.rawSegments.push(segment);
-						charInHiresBoundary = false;
-					}
-				} else {
-					this.rawSegments.push(segment);
-				}
-			}
-
 			if (original[originalCharIndex] === '\n') {
 				loc.line += 1;
 				loc.column = 0;
@@ -83,6 +62,27 @@ export default class Mappings {
 				this.generatedCodeColumn = 0;
 				first = true;
 			} else {
+				if (this.hires || first || sourcemapLocations.has(originalCharIndex)) {
+					const segment = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];
+
+					if (this.hires === 'boundary') {
+						// in hires "boundary", group segments per word boundary than per char
+						if (wordRegex.test(original[originalCharIndex])) {
+							// for first char in the boundary found, start the boundary by pushing a segment
+							if (!charInHiresBoundary) {
+								this.rawSegments.push(segment);
+								charInHiresBoundary = true;
+							}
+						} else {
+							// for non-word char, end the boundary by pushing a segment
+							this.rawSegments.push(segment);
+							charInHiresBoundary = false;
+						}
+					} else {
+						this.rawSegments.push(segment);
+					}
+				}
+
 				loc.column += 1;
 				this.generatedCodeColumn += 1;
 				first = false;

--- a/test/MagicString.js
+++ b/test/MagicString.js
@@ -528,6 +528,19 @@ describe('MagicString', () => {
 			assert.equal(loc8.line, 1);
 			assert.equal(loc8.column, 5);
 		});
+
+		it ('generates a source map without unneeded line break mappings', () => {
+			const s = new MagicString('function foo(){\n  console.log("bar")\n}');
+
+			const map = s.generateMap({
+				file: 'output.js',
+				source: 'input.js',
+				includeContent: true,
+				hires: 'boundary'
+			});
+
+			assert.equal(map.mappings, 'AAAA,QAAQ,CAAC,GAAG,CAAC,CAAC;AACd,CAAC,CAAC,OAAO,CAAC,GAAG,CAAC,CAAC,GAAG,CAAC;AACnB');
+		});
 	});
 
 	describe('getIndentString', () => {


### PR DESCRIPTION
This PR removes line break mappings from the output sourcemap and reduces the output sourcemap.
[visualizer before](https://evanw.github.io/source-map-visualization/#NDI2AGZ1bmN0aW9uIGZvbygpew0KICBjb25zb2xlLmxvZygiYmFyIikNCn0NCi8vIyBzb3VyY2VNYXBwaW5nVVJMPWRhdGE6YXBwbGljYXRpb24vanNvbjtjaGFyc2V0PXV0Zi04O2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKbWFXeGxJam9pYjNWMGNIVjBMbXB6SWl3aWMyOTFjbU5sY3lJNld5SnBibkIxZEM1cWN5SmRMQ0p6YjNWeVkyVnpRMjl1ZEdWdWRDSTZXeUptZFc1amRHbHZiaUJtYjI4b0tYdGNiaUFnWTI5dWMyOXNaUzVzYjJjb1hDSmlZWEpjSWlsY2JuMGlYU3dpYm1GdFpYTWlPbHRkTENKdFlYQndhVzVuY3lJNklrRkJRVUVzVVVGQlVTeERRVUZETEVkQlFVY3NRMEZCUXl4RFFVRkRMRU5CUVVNN1FVRkRaaXhEUVVGRExFTkJRVU1zVDBGQlR5eERRVUZETEVkQlFVY3NRMEZCUXl4RFFVRkRMRWRCUVVjc1EwRkJReXhEUVVGRE8wRkJRM0JDSW4wPTIzOQB7InZlcnNpb24iOjMsImZpbGUiOiJvdXRwdXQuanMiLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImZ1bmN0aW9uIGZvbygpe1xuICBjb25zb2xlLmxvZyhcImJhclwiKVxufSJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxRQUFRLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQztBQUNmLENBQUMsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUM7QUFDcEIifQ==)
[visualizer after](https://evanw.github.io/source-map-visualization/#NDE0AGZ1bmN0aW9uIGZvbygpew0KICBjb25zb2xlLmxvZygiYmFyIikNCn0NCi8vIyBzb3VyY2VNYXBwaW5nVVJMPWRhdGE6YXBwbGljYXRpb24vanNvbjtjaGFyc2V0PXV0Zi04O2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKbWFXeGxJam9pYjNWMGNIVjBMbXB6SWl3aWMyOTFjbU5sY3lJNld5SnBibkIxZEM1cWN5SmRMQ0p6YjNWeVkyVnpRMjl1ZEdWdWRDSTZXeUptZFc1amRHbHZiaUJtYjI4b0tYdGNiaUFnWTI5dWMyOXNaUzVzYjJjb1hDSmlZWEpjSWlsY2JuMGlYU3dpYm1GdFpYTWlPbHRkTENKdFlYQndhVzVuY3lJNklrRkJRVUVzVVVGQlVTeERRVUZETEVkQlFVY3NRMEZCUXl4RFFVRkRPMEZCUTJRc1EwRkJReXhEUVVGRExFOUJRVThzUTBGQlF5eEhRVUZITEVOQlFVTXNRMEZCUXl4SFFVRkhMRU5CUVVNN1FVRkRia0lpZlE9PTIyOQB7InZlcnNpb24iOjMsImZpbGUiOiJvdXRwdXQuanMiLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbImZ1bmN0aW9uIGZvbygpe1xuICBjb25zb2xlLmxvZyhcImJhclwiKVxufSJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxRQUFRLENBQUMsR0FBRyxDQUFDLENBQUM7QUFDZCxDQUFDLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEdBQUcsQ0FBQztBQUNuQiJ9)

esbuild does not output them and probably fine to skip them.
[example repl](https://esbuild.github.io/try/#YgAwLjI0LjAALS1idW5kbGUgLS1zb3VyY2VtYXAAZQBlbnRyeS5qcwBpbXBvcnQgJy4vZm9vLmpzJwppbXBvcnQgJy4vYmFyLmpzJwAAZm9vLmpzAGNvbnNvbGUubG9nKCdmb28nKQAAYmFyLmpzAGNvbnNvbGUubG9nKCdiYXInKQ)
[visualizer for that](https://evanw.github.io/source-map-visualization/#NDA1ACgoKSA9PiB7DQogIC8vIGZvby5qcw0KICBjb25zb2xlLmxvZygiZm9vIik7DQoNCiAgLy8gYmFyLmpzDQogIGNvbnNvbGUubG9nKCJiYXIiKTsNCn0pKCk7DQovLyMgc291cmNlTWFwcGluZ1VSTD1kYXRhOmFwcGxpY2F0aW9uL2pzb247YmFzZTY0LGV3b2dJQ0oyWlhKemFXOXVJam9nTXl3S0lDQWljMjkxY21ObGN5STZJRnNpWm05dkxtcHpJaXdnSW1KaGNpNXFjeUpkTEFvZ0lDSnpiM1Z5WTJWelEyOXVkR1Z1ZENJNklGc2lZMjl1YzI5c1pTNXNiMmNvSjJadmJ5Y3BJaXdnSW1OdmJuTnZiR1V1Ykc5bktDZGlZWEluS1NKZExBb2dJQ0p0WVhCd2FXNW5jeUk2SUNJN08wRkJRVUVzVlVGQlVTeEpRVUZKTEV0QlFVczdPenRCUTBGcVFpeFZRVUZSTEVsQlFVa3NTMEZCU3pzaUxBb2dJQ0p1WVcxbGN5STZJRnRkQ24wSzE5OAB7CiAgInZlcnNpb24iOiAzLAogICJzb3VyY2VzIjogWyJmb28uanMiLCAiYmFyLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJjb25zb2xlLmxvZygnZm9vJykiLCAiY29uc29sZS5sb2coJ2JhcicpIl0sCiAgIm1hcHBpbmdzIjogIjs7QUFBQSxVQUFRLElBQUksS0FBSzs7O0FDQWpCLFVBQVEsSUFBSSxLQUFLOyIsCiAgIm5hbWVzIjogW10KfQo=)


