### PR TITLE
feat: Add support for sourcemap `debugId` property

### DIFF
--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -25,6 +25,9 @@ export default class SourceMap {
 		if (typeof properties.x_google_ignoreList !== 'undefined') {
 			this.x_google_ignoreList = properties.x_google_ignoreList;
 		}
+		if (typeof properties.debugId !== 'undefined') {
+			this.debugId = properties.debugId;
+		}
 	}
 
 	toString() {


### PR DESCRIPTION
Debug IDs are unique uuids added to both source and sourcemaps so sourcemaps can more easily be identified in production. See the [TC39 proposal](https://github.com/tc39/source-map/blob/main/proposals/debug-id.md) for more details

I've recently added support for emitting debug IDs in [Rollup](https://rollupjs.org/configuration-options/#output-sourcemapdebugids), webpack and Rolldown.

Even though this has been released in Rollup, it doesn't work In Vite yet because the debug ID gets removed from every sourcemap when a later plugin makes modifications to the sourcemap. I think I've tracked this down to `magic-string`!

