### PR TITLE
feat: Include `debugId` in `SourceMap` types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,6 +53,7 @@ export class SourceMap {
   names: string[];
   mappings: string;
   x_google_ignoreList?: number[];
+  debugId?: string;
 
   /**
    * Returns the equivalent of `JSON.stringify(map)`


### PR DESCRIPTION
Sorry, in #292 I failed to update the `SourceMap` type to include the new property!