### PR TITLE
feat: add `sideEffects: false` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Rich Harris",
   "main": "./dist/magic-string.cjs.js",
   "module": "./dist/magic-string.es.mjs",
+  "sideEffects": false,
   "jsnext:main": "./dist/magic-string.es.mjs",
   "types": "./dist/magic-string.cjs.d.ts",
   "exports": {


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.