### PR TITLE
fix: missing mapping after a line break with `hires: 'boundary'`

### DIFF
--- a/src/utils/Mappings.js
+++ b/src/utils/Mappings.js
@@ -61,6 +61,7 @@ export default class Mappings {
 				this.raw[this.generatedCodeLine] = this.rawSegments = [];
 				this.generatedCodeColumn = 0;
 				first = true;
+				charInHiresBoundary = false;
 			} else {
 				if (this.hires || first || sourcemapLocations.has(originalCharIndex)) {
 					const segment = [this.generatedCodeColumn, sourceIndex, loc.line, loc.column];

--- a/test/MagicString.test.js
+++ b/test/MagicString.test.js
@@ -487,6 +487,37 @@ describe('MagicString', () => {
 			assert.equal(loc.column, 33);
 		});
 
+		it('generates segments per word boundary with hires "boundary" in the next line', () => {
+			const s = new MagicString('// foo\nconsole.log("bar")');
+
+			// rename bar to hello
+			s.overwrite(20, 23, 'hello');
+
+			const map = s.generateMap({
+				file: 'output.js',
+				source: 'input.js',
+				includeContent: true,
+				hires: 'boundary',
+			});
+
+			assert.equal(
+				map.mappings,
+				'AAAA,CAAC,CAAC,CAAC;AACH,OAAO,CAAC,GAAG,CAAC,CAAC,KAAG,CAAC',
+			);
+
+			const smc = new SourceMapConsumer(map);
+			let loc;
+
+			loc = smc.originalPositionFor({ line: 2, column: 2 });
+			console.log(loc.source)
+			assert.equal(loc.line, 2);
+			assert.equal(loc.column, 0);
+
+			loc = smc.originalPositionFor({ line: 2, column: 12 });
+			assert.equal(loc.line, 2);
+			assert.equal(loc.column, 12);
+		});
+
 		it('generates a correct source map with update using a content containing a new line', () => {
 			const s = new MagicString('foobar');
 			s.update(3, 4, '\nbb');

--- a/test/MagicString.test.js
+++ b/test/MagicString.test.js
@@ -509,7 +509,6 @@ describe('MagicString', () => {
 			let loc;
 
 			loc = smc.originalPositionFor({ line: 2, column: 2 });
-			console.log(loc.source)
 			assert.equal(loc.line, 2);
 			assert.equal(loc.column, 0);
 


### PR DESCRIPTION
In some cases, a mapping was missing after a line break with `hires: 'boundary'`.

[Example output](https://evanw.github.io/source-map-visualization/#MjgALy8gZm9vCmNvbnNvbGUubG9nKCJoZWxsbyIpCjE4NQB7InZlcnNpb24iOjMsImZpbGUiOiJvdXRwdXQuanMiLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGZvb1xuY29uc29sZS5sb2coXCJiYXJcIikiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQ0FBQyxDQUFDLENBQUM7T0FDSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUcsQ0FBQyJ9Cg==)

This PR fixes that. [Example new output](https://evanw.github.io/source-map-visualization/#MjgALy8gZm9vCmNvbnNvbGUubG9nKCJoZWxsbyIpCjE5MAB7InZlcnNpb24iOjMsImZpbGUiOiJvdXRwdXQuanMiLCJzb3VyY2VzIjpbImlucHV0LmpzIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIGZvb1xuY29uc29sZS5sb2coXCJiYXJcIikiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQ0FBQyxDQUFDLENBQUM7QUFDSCxPQUFPLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBRyxDQUFDIn0K)
