### PR TITLE
fix: this.outro need to be mapped

### DIFF
--- a/src/MagicString.js
+++ b/src/MagicString.js
@@ -168,6 +168,10 @@ export default class MagicString {
 			if (chunk.outro.length) mappings.advance(chunk.outro);
 		});
 
+		if (this.outro) {
+			mappings.advance(this.outro);
+		}
+
 		return {
 			file: options.file ? options.file.split(/[/\\]/).pop() : undefined,
 			sources: [


### PR DESCRIPTION
```js
const s = new MagicString(
  'var answer = 42;\nconsole.log("the answer is %s", answer);'
)
s.append('\n\n\n\n}).call(global);')
```
Then `s.toString().split('\n').length` equals to `6`, which means output has 6 lines.  

So for its sourcemap, `s.generateMap().mappings` should also has 6 lines. But now it only has 2 lines.

### Expected output
```
AAAA;AACA;;;;
```

### Expected output
```
AAAA;AACA;;;;
```

