### PR TITLE
perf: add fast path for non-exclusion indent

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -38,6 +38,8 @@ export type ReplacementFunction = (substring: string, ...args: any[]) => string
 declare const DEBUG: boolean
 
 const n = '\n'
+const NEWLINE_CHAR = '\n'.charCodeAt(0)
+const CR_CHAR = '\r'.charCodeAt(0)
 
 const warned = {
   insertLeft: false,
@@ -365,6 +367,19 @@ export default class MagicString {
     let charIndex = 0
     let chunk = this.firstChunk
 
+    const indentAt = (index: number) => {
+      shouldIndentNextCharacter = false
+
+      if (index === chunk!.start) {
+        chunk!.prependRight(resolvedIndentStr)
+      }
+      else {
+        this._splitChunk(chunk!, index)
+        chunk = chunk!.next
+        chunk!.prependRight(resolvedIndentStr)
+      }
+    }
+
     while (chunk) {
       const end = chunk.end
 
@@ -377,30 +392,46 @@ export default class MagicString {
           }
         }
       }
-      else {
+      else if (options.exclude) {
         charIndex = chunk.start
 
         while (charIndex < end) {
           if (!isExcluded[charIndex]) {
-            const char = this.original[charIndex]
+            const char = this.original.charCodeAt(charIndex)
 
-            if (char === '\n') {
+            if (char === NEWLINE_CHAR) {
               shouldIndentNextCharacter = true
             }
-            else if (char !== '\r' && shouldIndentNextCharacter) {
-              shouldIndentNextCharacter = false
-
-              if (charIndex === chunk.start) {
-                chunk.prependRight(resolvedIndentStr)
-              }
-              else {
-                this._splitChunk(chunk, charIndex)
-                chunk = chunk.next
-                chunk.prependRight(resolvedIndentStr)
-              }
+            else if (char !== CR_CHAR && shouldIndentNextCharacter) {
+              indentAt(charIndex)
             }
           }
 
+          charIndex += 1
+        }
+      }
+      else {
+        charIndex = chunk.start
+
+        while (charIndex < end) {
+          if (!shouldIndentNextCharacter) {
+            const nextLine = this.original.indexOf(n, charIndex)
+            if (nextLine === -1 || nextLine >= end)
+              break
+
+            shouldIndentNextCharacter = true
+            charIndex = nextLine + 1
+            continue
+          }
+
+          const char = this.original.charCodeAt(charIndex)
+
+          if (char === NEWLINE_CHAR || char === CR_CHAR) {
+            charIndex += 1
+            continue
+          }
+
+          indentAt(charIndex)
           charIndex += 1
         }
       }


### PR DESCRIPTION
When indenting, we only need to iterate every character when there's an
exclusion set (options.exclude). When this isn't set, we can instead
jump ahead to the next newline character one by one.

This means we save having to iterate the entire string and can just
iterate the newline occurrences.

Benchmark results:

> construct x 220,284 ops/sec ±0.23% (97 runs sampled)
> append x 21,550,199 ops/sec ±2.47% (73 runs sampled)
> **indent x 13,679 ops/sec ±1.80% (85 runs sampled)**
> generateMap (no edit) x 2,961 ops/sec ±1.17% (99 runs sampled)
> generateMap (edit) x 3,125 ops/sec ±0.08% (100 runs sampled)
> generateDecodedMap (no edit) x 3,351 ops/sec ±0.52% (101 runs sampled)
> generateDecodedMap (edit) x 3,347 ops/sec ±0.43% (100 runs sampled)
> overwrite x 6.27 ops/sec ±2.10% (20 runs sampled)

Previous results on same machine:

> construct x 213,647 ops/sec ±0.17% (100 runs sampled)
> append x 21,184,532 ops/sec ±3.34% (71 runs sampled)
> **indent x 4,522 ops/sec ±0.20% (101 runs sampled)**
> generateMap (no edit) x 2,930 ops/sec ±1.42% (98 runs sampled)
> generateMap (edit) x 3,100 ops/sec ±0.43% (99 runs sampled)
> generateDecodedMap (no edit) x 3,374 ops/sec ±0.09% (101 runs sampled)
> generateDecodedMap (edit) x 3,371 ops/sec ±0.05% (101 runs sampled)
> overwrite x 6.22 ops/sec ±2.00% (20 runs sampled)
