### PR TITLE
chore: disable sourcemaps

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  sourcemap: true,
   define: {
     DEBUG: 'false',
   },


### PR DESCRIPTION
Since the build output is readable, we don't really need to ship sourcemaps for the minority that debug their node_modules. Keep in mind that Chrome ignores all node_modules sourcemaps by default these days too.

cc @antfu 