### PR TITLE
fix: validate update() range and show indices in range errors

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -577,6 +577,8 @@ export default class MagicString {
       while (end < 0) end += this.original.length
     }
 
+    if (start < 0)
+      throw new Error('Character is out of bounds')
     if (end > this.original.length)
       throw new Error('end is out of bounds')
     if (start === end) {
@@ -584,6 +586,8 @@ export default class MagicString {
         'Cannot overwrite a zero-length range – use appendLeft or prependRight instead',
       )
     }
+    if (start > end)
+      throw new Error(`end must be greater than start (start: ${start}, end: ${end})`)
 
     if (DEBUG)
       this.stats.time('overwrite')
@@ -729,7 +733,7 @@ export default class MagicString {
     if (start < 0 || end > this.original.length)
       throw new Error('Character is out of bounds')
     if (start > end)
-      throw new Error('end must be greater than start')
+      throw new Error(`end must be greater than start (start: ${start}, end: ${end})`)
 
     if (DEBUG)
       this.stats.time('remove')
@@ -770,7 +774,7 @@ export default class MagicString {
     if (start < 0 || end > this.original.length)
       throw new Error('Character is out of bounds')
     if (start > end)
-      throw new Error('end must be greater than start')
+      throw new Error(`end must be greater than start (start: ${start}, end: ${end})`)
 
     if (DEBUG)
       this.stats.time('reset')

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1164,6 +1164,22 @@ describe('magicString', () => {
       assert.throws(() => s.update(0, 1, []), TypeError)
     })
 
+    it('should throw when start is greater than end', () => {
+      const s = new MagicString('problems = 99')
+      assert.throws(() => s.update(9, 5, 'x'), /end must be greater than start \(start: 9, end: 5\)/)
+    })
+
+    it('should report the resolved indices when a negative start lands past end', () => {
+      const s = new MagicString('problems = 99')
+      // -1 resolves to 12, which is past `end`
+      assert.throws(() => s.update(-1, 5, 'x'), /end must be greater than start \(start: 12, end: 5\)/)
+    })
+
+    it('should throw error when using negative indices with empty string', () => {
+      const s = new MagicString('')
+      assert.throws(() => s.update(-2, -1, 'x'), /Character is out of bounds/)
+    })
+
     it('replaces interior inserts with overwrite option', () => {
       const s = new MagicString('abcdefghijkl')
 
@@ -1364,6 +1380,12 @@ describe('magicString', () => {
     it('should throw error when using negative indices with empty string', () => {
       const s = new MagicString('')
       assert.throws(() => s.remove(-2, -1), /Character is out of bounds/)
+    })
+
+    it('should report the resolved indices when a negative start lands past end', () => {
+      const s = new MagicString('problems = 99')
+      // -1 resolves to 12, which is past `end`
+      assert.throws(() => s.remove(-1, 5), /end must be greater than start \(start: 12, end: 5\)/)
     })
   })
 


### PR DESCRIPTION
### What

`update()` was missing the `start < 0` and `start > end` guards that `remove()` and `reset()` already have, so an out-of-order range fell through to chunk walking and surfaced as `Cannot overwrite across a split point` (#288).

Range errors also never showed the indices they were complaining about. Negative indices are resolved against `original.length` before validation, so `s.remove(-1, 5)` on a 13-character string reports `end must be greater than start` while the caller is looking at `-1` and `5` and sees nothing wrong (#260).

### Changes

- `update()`: added the two missing guards, mirroring `remove()` / `reset()`.
- `remove()`, `reset()`, `update()`: `end must be greater than start` now includes the resolved indices.

Before:

```js
const s = new MagicString('problems = 99')

s.remove(-1, 5)        // Error: end must be greater than start
s.update(-1, 5, 'x')   // Error: Cannot overwrite across a split point
```

After:

```js
const s = new MagicString('problems = 99')

s.remove(-1, 5)        // Error: end must be greater than start (start: 12, end: 5)
s.update(-1, 5, 'x')   // Error: end must be greater than start (start: 12, end: 5)
```

Closes #288
Closes #260

### Notes

No existing message text was removed, so assertions matching the old substrings still pass. 225 tests pass, `tsc` and `eslint` are clean.
