### PR TITLE
docs: document remaining public methods and correct the removed ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ The returned sourcemap has two (non-enumerable) methods attached for convenience
 code += `\n//# sourceMappingURL=${map.toUrl()}`
 ```
 
+### s.getIndentString()
+
+Returns the indentation string guessed from the original content, falling back to a single tab character. This is the value `s.indent()` uses when no prefix is supplied.
+
 ### s.hasChanged()
 
 Indicates if the string has been changed.
@@ -158,13 +162,39 @@ The `options` argument can have an `exclude` property, which is an array of `[st
 
 Returns true if the resulting source is empty (disregarding white space).
 
+### s.lastChar()
+
+Returns the last character of the generated string, or `''` if it is empty.
+
+### s.lastLine()
+
+Returns everything after the last newline in the generated string, or the whole string if there is no newline.
+
+### s.length()
+
+Returns the length of the generated string, counting only content attached to the original characters. Content that sits outside the string body is not counted, so `s.length()` and `s.toString().length` can disagree:
+
+```js
+const s = new MagicString('abcde')
+
+s.appendLeft(2, '__')
+s.toString() // 'ab__cde'
+s.length() // 7
+
+s.prepend('>>')
+s.toString() // '>>ab__cde'
+s.length() // still 7
+```
+
+`s.prepend()` and `s.append()` always land outside the body, as do inserts made before the first character or after the last one.
+
 ### s.locate( index )
 
-**DEPRECATED** since 0.10 – see [#30](https://github.com/Rich-Harris/magic-string/pull/30)
+**REMOVED** in 0.13, deprecated since 0.10 – see [#30](https://github.com/Rich-Harris/magic-string/pull/30)
 
 ### s.locateOrigin( index )
 
-**DEPRECATED** since 0.10 – see [#30](https://github.com/Rich-Harris/magic-string/pull/30)
+**REMOVED** in 0.13, deprecated since 0.10 – see [#30](https://github.com/Rich-Harris/magic-string/pull/30)
 
 ### s.move( start, end, index )
 


### PR DESCRIPTION
### What

Comparing the class surface against the README turned up gaps in both directions.

**In the published types but not in the README:** `getIndentString()`, `lastChar()`, `lastLine()`, `length()`. All four survive into `dist/index.d.mts`, so they are public API, but the only way to discover them was reading the source. (`insert()`, `trimStartAborted()` and `trimEndAborted()` are marked `@internal` and stripped from the declarations, so I left those alone.)

**In the README but not anywhere:** `s.locate()` and `s.locateOrigin()` are still listed as `DEPRECATED since 0.10`, which reads as "still here, just discouraged". They were actually removed in `961564b`, which landed in v0.13.0, and they do not appear in the declarations. I changed the note to say removed rather than deleting the sections, so anyone searching for the name still finds an answer. Happy to drop the sections entirely if you would rather.

### On `length()`

Worth calling out because it surprised me: `s.length()` counts only content attached to a chunk, so it can disagree with `s.toString().length`.

```js
const s = new MagicString('abcde')

s.appendLeft(2, '__')
s.toString() // 'ab__cde'
s.length() // 7

s.prepend('>>')
s.toString() // '>>ab__cde'
s.length() // still 7
```

The same applies to `s.append()`, and to inserts placed before the first character or after the last one, since those land in the string-level intro/outro rather than on a chunk. The existing `describe('length')` test already locks this in, so I documented it as-is rather than treating it as a bug.

Every claim above was checked against `main`.
