### PR TITLE
fix: count separators in Bundle#length

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -307,10 +307,12 @@ export default class Bundle {
   }
 
   length(): number {
-    return this.sources.reduce(
-      (length, source) => length + source.content.length(),
-      this.intro.length,
-    )
+    return this.sources.reduce((length, source, i) => {
+      // mirrors toString(): every source but the first is preceded by a separator
+      const separator = source.separator !== undefined ? source.separator : this.separator
+
+      return length + (i > 0 ? separator.length : 0) + source.content.length()
+    }, this.intro.length)
   }
 
   trimLines(): this {

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -642,6 +642,45 @@ describe('bundle', () => {
     })
   })
 
+  describe('length', () => {
+    it('should count the default separator between sources', () => {
+      const b = new Bundle()
+
+      b.addSource(new MagicString('abc'))
+      b.addSource(new MagicString('def'))
+
+      assert.equal(b.toString(), 'abc\ndef')
+      assert.equal(b.length(), b.toString().length)
+    })
+
+    it('should count a custom separator', () => {
+      const b = new Bundle({ separator: '\n\n' })
+
+      b.addSource(new MagicString('a'))
+      b.addSource(new MagicString('b'))
+      b.addSource(new MagicString('c'))
+
+      assert.equal(b.length(), b.toString().length)
+    })
+
+    it('should count a per-source separator', () => {
+      const b = new Bundle({ separator: '\n\n' })
+
+      b.addSource(new MagicString('a'))
+      b.addSource({ content: new MagicString('b'), separator: '; ' })
+
+      assert.equal(b.length(), b.toString().length)
+    })
+
+    it('should count the intro', () => {
+      const b = new Bundle({ intro: '// intro\n' })
+
+      b.addSource(new MagicString('abc'))
+
+      assert.equal(b.length(), b.toString().length)
+    })
+  })
+
   describe('prepend', () => {
     it('should append content', () => {
       const b = new Bundle()


### PR DESCRIPTION
### What

`Bundle#length` starts the reduce at `this.intro.length` and then adds each source's length, but it never adds the separators that `toString()` inserts between sources. So it counts the bundle's own intro yet not the bundle's own separators:

```js
const b = new Bundle()

b.addSource(new MagicString('abc'))
b.addSource(new MagicString('def'))

b.toString() // 'abc\ndef'
b.toString().length // 7
b.length() // 6
```

The gap grows with the source count and the separator width. Three sources with the default `'\n'` reported 3 instead of 5; two sources with `separator: '\n\n'` reported 2 instead of 4.

### Fix

The reduce now mirrors `toString()`, using the same `source.separator !== undefined ? source.separator : this.separator` resolution so a per-source override is counted correctly too.

### Tests

`Bundle#length` had no test at all, so I added a `describe('length')` block with four cases: default separator, custom separator, per-source separator override, and intro. The first three fail on `master` (6 vs 7, 3 vs 5, 2 vs 4) and pass with this change. The fourth passes either way and pins the intro behaviour that was already correct.

Full suite goes from 225 to 229 passing, `tsc` and `eslint` clean.

### One known difference left

`bundle.length()` can still differ from `bundle.toString().length` when a source `MagicString` had `prepend()` or `append()` applied to it, because `MagicString#length` deliberately excludes those (there is an existing test pinning that, and the README documents it). That is a separate question about `MagicString#length`, so I left it alone here.
