### PR TITLE
fix: use a source's own separator in Bundle sourcemaps

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -148,7 +148,8 @@ export default class Bundle {
 
     this.sources.forEach((source, i) => {
       if (i > 0) {
-        mappings.advance(this.separator)
+        // mirrors toString(): a source can override the bundle separator
+        mappings.advance(source.separator !== undefined ? source.separator : this.separator)
       }
 
       const sourceIndex = source.filename ? this.uniqueSourceIndexByFilename[source.filename] : -1

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -489,6 +489,45 @@ describe('bundle', () => {
       })
     })
 
+    it('should use a source\'s own separator', () => {
+      const b = new Bundle({ separator: '\n' })
+
+      b.addSource({ filename: 'a.js', content: new MagicString('AAA') })
+      b.addSource({
+        filename: 'b.js',
+        content: new MagicString('BBB'),
+        separator: '\n\n\n',
+      })
+
+      assert.equal(b.toString(), 'AAA\n\n\nBBB')
+
+      const map = b.generateMap({ file: 'out.js', includeContent: true })
+      const smc = new SourceMapConsumer(map as unknown as RawSourceMap)
+      const loc = smc.originalPositionFor({ line: 4, column: 0 })
+
+      assert.equal(loc.source, 'b.js')
+      assert.equal(loc.line, 1)
+      assert.equal(loc.column, 0)
+    })
+
+    it('should stay aligned after append', () => {
+      const b = new Bundle()
+
+      b.addSource({ filename: 'a.js', content: new MagicString('AAA') })
+      b.append('XXX')
+      b.addSource({ filename: 'b.js', content: new MagicString('BBB') })
+
+      assert.equal(b.toString(), 'AAAXXX\nBBB')
+
+      const map = b.generateMap({ file: 'out.js', includeContent: true })
+      const smc = new SourceMapConsumer(map as unknown as RawSourceMap)
+      const loc = smc.originalPositionFor({ line: 2, column: 0 })
+
+      assert.equal(loc.source, 'b.js')
+      assert.equal(loc.line, 1)
+      assert.equal(loc.column, 0)
+    })
+
     // TODO tidy this up. is a recreation of a bug in Svelte
     it('generates a correct sourcemap for a Svelte component', () => {
       const b = new Bundle({


### PR DESCRIPTION
### What

`toString()` resolves the separator per source:

```js
const separator = source.separator !== undefined ? source.separator : this.separator
```

`generateDecodedMap()` does not. It always advances the mappings by `this.separator`, so as soon as one source carries its own separator, the sourcemap and the output disagree about where every later source starts.

```js
const b = new Bundle({ separator: '\n' })

b.addSource({ filename: 'a.js', content: new MagicString('AAA') })
b.addSource({ filename: 'b.js', content: new MagicString('BBB'), separator: '\n\n\n' })

b.toString() // 'AAA\n\n\nBBB', so BBB is on line 4
```

The map claims `b.js` is on line 2, which is blank, and line 4 maps to nothing at all.

`append()` hits this on its own, without anyone setting a separator by hand, because it adds its content with `separator: ''`:

```js
const b = new Bundle()

b.addSource({ filename: 'a.js', content: new MagicString('AAA') })
b.append('XXX')
b.addSource({ filename: 'b.js', content: new MagicString('BBB') })

b.toString() // 'AAAXXX\nBBB'
```

Here `b.js` on line 2 has no mapping either, because the mappings advanced by one `'\n'` too many.

### Fix

One line: the mappings resolve the separator exactly the way `toString()` does.

### Tests

Two added to the `generateMap` block, one per case above. Both fail on `master` with `expected null to equal 'b.js'` and pass with this change.

The existing separator coverage did not catch this because `should handle empty separator` and the Svelte regression test both set the separator on the `Bundle`, where the two code paths already agree. The per-source `separator` property had no sourcemap test at all.

Full suite goes from 225 to 227 passing, `tsc` and `eslint` clean.
