### PR TITLE
fix: throw instead of corrupting the chunk list on an overlapping move

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -78,12 +78,7 @@ export default class MagicString {
   declare indentStr: string | null | undefined
   /** @internal */
   declare stats: Stats
-
-  /**
-   * Whether move() has reordered the chunk list. Only move() can, so until it
-   * has, any range is still a forward run and move()'s ordering check can be
-   * skipped.
-   */
+  /** @internal */
   declare hasMovedChunks: boolean
 
   constructor(string: string, options: MagicStringOptions = {}) {
@@ -232,9 +227,6 @@ export default class MagicString {
 
     cloned.intro = this.intro
     cloned.outro = this.outro
-
-    // The clone copies the chunks in their current order, so it inherits any
-    // reordering and needs move()'s ordering check for the same reason.
     cloned.hasMovedChunks = this.hasMovedChunks
 
     return cloned as this

--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -79,6 +79,13 @@ export default class MagicString {
   /** @internal */
   declare stats: Stats
 
+  /**
+   * Whether move() has reordered the chunk list. Only move() can, so until it
+   * has, any range is still a forward run and move()'s ordering check can be
+   * skipped.
+   */
+  declare hasMovedChunks: boolean
+
   constructor(string: string, options: MagicStringOptions = {}) {
     const chunk = new Chunk(0, string.length, string)
 
@@ -98,6 +105,7 @@ export default class MagicString {
       indentStr: { writable: true, value: undefined },
       ignoreList: { writable: true, value: options.ignoreList },
       offset: { writable: true, value: options.offset || 0 },
+      hasMovedChunks: { writable: true, value: false },
     })
 
     if (DEBUG) {
@@ -224,6 +232,10 @@ export default class MagicString {
 
     cloned.intro = this.intro
     cloned.outro = this.outro
+
+    // The clone copies the chunks in their current order, so it inherits any
+    // reordering and needs move()'s ordering check for the same reason.
+    cloned.hasMovedChunks = this.hasMovedChunks
 
     return cloned as this
   }
@@ -500,6 +512,26 @@ export default class MagicString {
     const first = this.byStart.get(start)
     const last = this.byEnd.get(end)
 
+    // The splicing below assumes the chunks spanning [start, end) are still a
+    // forward run in the current list. An earlier move can have interleaved a
+    // chunk from outside the range, or put `last` before `first`, and then the
+    // pointer rewrites produce a cycle rather than an error, so toString() and
+    // generateMap() loop forever.
+    //
+    // Only move() reorders chunks, so this is skipped until one has run, which
+    // keeps the common single-move case free of the walk.
+    if (this.hasMovedChunks) {
+      let cursor = first
+      while (cursor !== last) {
+        cursor = cursor.next
+        if (!cursor || cursor.start < start || cursor.end > end) {
+          throw new MagicStringError(
+            `cannot move ${start} to ${end} because an earlier move split that range`,
+          )
+        }
+      }
+    }
+
     const oldLeft = first.previous
     const oldRight = last.next
 
@@ -532,6 +564,8 @@ export default class MagicString {
       this.firstChunk = first
     if (!newRight)
       this.lastChunk = last
+
+    this.hasMovedChunks = true
 
     if (DEBUG)
       this.stats.timeEnd('move')

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -876,6 +876,31 @@ describe('magicString', () => {
       assert.throws(() => s.move(3, 6, 6), /cannot move a selection inside itself/)
     })
 
+    it('refuses to move a range an earlier move has split', () => {
+      // The second move's range spans chunks the first move separated, so they
+      // are no longer a forward run in the list. Splicing them anyway used to
+      // point a chunk at itself, and toString() then looped forever.
+      const s = new MagicString('abcdef')
+      s.move(0, 2, 3)
+
+      assert.throws(() => s.move(1, 3, 0), /earlier move split that range/)
+
+      // The first move is still intact and the string is still printable.
+      assert.equal(s.toString(), 'cabdef')
+    })
+
+    it('carries the reordering over to a clone', () => {
+      // clone() copies the chunks in their current order, so the clone starts
+      // out reordered and needs the same check.
+      const s = new MagicString('abcdef')
+      s.move(0, 2, 3)
+
+      const cloned = s.clone()
+
+      assert.throws(() => cloned.move(1, 3, 0), /earlier move split that range/)
+      assert.equal(cloned.toString(), 'cabdef')
+    })
+
     it('does nothing when moving a zero-length range', () => {
       const s = new MagicString('abcdefghijkl')
 


### PR DESCRIPTION
Fixes #325.

### The problem

```js
const s = new MagicString('abcdef')
s.move(0, 2, 3)
s.move(1, 3, 0)
s.toString() // never returns
```

Both calls are in bounds and neither throws. The second one corrupts the chunk list into a cycle, and every later `toString()` or `generateMap()` spins at 100% CPU.

`move()` looks the range up as `byStart.get(start)` and `byEnd.get(end)` and then splices, which assumes those two chunks are still the ends of a forward run. After `move(0, 2, 3)` the order is `c(2,3) a(0,1) b(1,2) d(3,4)…`, so the second call gets `first = b(1,2)` and `last = c(2,3)` with `last` sitting *before* `first`. The pointer rewrites then leave `a(0,1).next === a(0,1)`, and the walk in `toString()` has nowhere to stop.

### The change

Before splicing, walk from `first` to `last` and confirm every chunk on the way is still inside `[start, end)`. If the run has been broken up, throw a `MagicStringError` instead of building a cycle. That matches what `move()` already does for the other case it cannot honour, `cannot move a selection inside itself`.

Only `move()` reorders chunks, so the walk is skipped entirely until one has run. A first move, which is the overwhelmingly common case, costs nothing extra. I added `hasMovedChunks` for that, and `clone()` copies it: a clone rebuilds the chunks in their current order, so it inherits any reordering and needs the same check. Without that line a clone of a moved string still hung, which I only noticed after reading `clone()`, so there is a test for it.

I went with throwing rather than trying to define an ordering for overlapping moves, since that is a semantics decision rather than a bug fix, and the issue offered either. Happy to look at handling the case properly instead if you would prefer that.

### Tests

Two cases in the existing `move` block, both failing on `main`:

- the sequence from the issue throws, and the first move is left intact and printable
- the same through `clone()`, covering the flag being carried over

233 passing, lint clean. The existing `handles moves to same index` test, which does two moves where the second does not straddle the first, still passes and was the main thing I wanted to be sure of.
