### PR TITLE
fix: count separators in Bundle#isEmpty

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -303,8 +303,14 @@ export default class Bundle {
   isEmpty(): boolean {
     if (this.intro.length && this.intro.trim())
       return false
-    if (this.sources.some(source => !source.content.isEmpty()))
+    if (this.sources.some((source, i) => {
+      // mirrors toString(): every source but the first is preceded by a separator
+      const separator = source.separator !== undefined ? source.separator : this.separator
+
+      return (i > 0 && separator.trim() !== '') || !source.content.isEmpty()
+    })) {
       return false
+    }
     return true
   }
 

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -681,6 +681,47 @@ describe('bundle', () => {
     })
   })
 
+  describe('isEmpty', () => {
+    it('should ignore a whitespace separator', () => {
+      const b = new Bundle()
+
+      b.addSource(new MagicString(''))
+      b.addSource(new MagicString(''))
+
+      assert.equal(b.toString(), '\n')
+      assert.equal(b.isEmpty(), true)
+    })
+
+    it('should see a custom separator', () => {
+      const b = new Bundle({ separator: ';' })
+
+      b.addSource(new MagicString(''))
+      b.addSource(new MagicString(''))
+
+      assert.equal(b.toString(), ';')
+      assert.equal(b.isEmpty(), false)
+    })
+
+    it('should see a per-source separator', () => {
+      const b = new Bundle()
+
+      b.addSource(new MagicString(''))
+      b.addSource({ content: new MagicString(''), separator: ';' })
+
+      assert.equal(b.toString(), ';')
+      assert.equal(b.isEmpty(), false)
+    })
+
+    it('should ignore the separator of a lone source', () => {
+      const b = new Bundle({ separator: ';' })
+
+      b.addSource(new MagicString(''))
+
+      assert.equal(b.toString(), '')
+      assert.equal(b.isEmpty(), true)
+    })
+  })
+
   describe('length', () => {
     it('should count the default separator between sources', () => {
       const b = new Bundle()


### PR DESCRIPTION
This is the same oversight as #322 and #323, in the last method of `Bundle` that touches separators.

The README says `isEmpty()` "returns true if the resulting source is empty (disregarding white space)", so it should agree with `toString()`. It did not, because it only looked at the intro and the sources and never at the separators that `toString()` puts between them:

| bundle | `toString()` | `isEmpty()` before | should be |
| --- | --- | --- | --- |
| two empty sources, default separator | `"\n"` | `true` | `true` |
| two empty sources, `separator: ';'` | `";"` | `true` | `false` |
| three empty sources, `separator: '---'` | `"------"` | `true` | `false` |
| second source carries `separator: ';'` | `";"` | `true` | `false` |
| one source, `separator: ';'` unused | `""` | `true` | `true` |

The default separator is `\n`, which is white space, so the common case was already right and this stayed hidden.

The fix mirrors `toString()` the same way `length()` does since #322: every source but the first is preceded by a separator, and a source may override the bundle one. Whitespace separators are still ignored, which keeps the default behaviour and the "disregarding white space" wording intact.

### Tests

`Bundle#isEmpty` had no tests at all, which is what made it worth a closer look. `MagicString#isEmpty` does have one, and its behaviour is deliberate. The same signal pointed at the `length()` bug in #322.

Four cases added under a new `isEmpty` describe. Against master the two that involve a non whitespace separator fail with `expected true to equal false`, and the two control cases pass, so they are guarding the change rather than restating it.

Suite goes from 231 to 235 passing. `tsc --noEmit` is clean and `eslint` is clean.