### PR TITLE
perf: optimize `hasChanged`

### DIFF
--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -5,7 +5,7 @@ import MagicString from '../dist/index.mjs'
 Benchmark.support.decompilation = false
 
 const results = []
-const total = 8
+const total = 10
 const isTTY = process.stdout.isTTY
 let current = 0
 
@@ -125,6 +125,20 @@ async function bench() {
       s.overwrite(i, i + 1, 'b')
     }
   })
+
+  await runWithInstance('hasChanged (no edit)', inputs, (s) => {
+    s.hasChanged()
+  })
+  await runWithInstance(
+    'hasChanged (edit)',
+    inputs,
+    (s) => {
+      s.hasChanged()
+    },
+    (s) => {
+      s.replace(/replacement/g, 'replacement\nReplacement')
+    },
+  )
 
   printResults()
 }

--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1153,7 +1153,36 @@ export default class MagicString {
    * Indicates if the string has been changed.
    */
   hasChanged(): boolean {
-    return this.original !== this.toString()
+    if (this.intro || this.outro)
+      return true
+
+    let originalIndex = 0
+    let chunk: Chunk | null = this.firstChunk
+
+    while (chunk) {
+      // Any intro/outro on a chunk means content was inserted
+      if (chunk.intro || chunk.outro)
+        return true
+
+      // Chunks must be in original order, otherwise content was moved
+      if (chunk.start !== originalIndex)
+        return true
+
+      // For edited chunks, check if content actually differs from original;
+      // compare lengths first so a slice is only allocated when they match
+      if (
+        chunk.edited
+        && (chunk.content.length !== chunk.end - chunk.start
+          || chunk.content !== this.original.slice(chunk.start, chunk.end))
+      ) {
+        return true
+      }
+
+      originalIndex = chunk.end
+      chunk = chunk.next
+    }
+
+    return originalIndex !== this.original.length
   }
 
   /** @internal */

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1891,6 +1891,54 @@ describe('magicString', () => {
 
       assert.ok(clone.hasChanged())
     })
+
+    it('should return false when edited content is identical to the original', () => {
+      const s = new MagicString('abcdef')
+
+      s.overwrite(0, 6, 'abcdef')
+      assert.ok(!s.hasChanged())
+
+      const t = new MagicString('abcdef')
+
+      t.update(2, 4, 'cd')
+      assert.ok(!t.hasChanged())
+    })
+
+    it('should return false after reset reverts the edits', () => {
+      const s = new MagicString('abcdef')
+
+      s.remove(1, 3)
+      assert.ok(s.hasChanged())
+
+      s.reset(1, 3)
+      assert.ok(!s.hasChanged())
+    })
+
+    it('should return true when content is only moved', () => {
+      const s = new MagicString('abcdef')
+
+      s.move(0, 2, 6)
+      assert.ok(s.hasChanged())
+    })
+
+    it('should return true when content is inserted without changing existing characters', () => {
+      const s = new MagicString('abcdef')
+
+      s.appendLeft(3, '/* comment */')
+      assert.ok(s.hasChanged())
+
+      const t = new MagicString('abcdef')
+
+      t.append(' // end')
+      assert.ok(t.hasChanged())
+    })
+
+    it('should return true when trailing content is removed (chain no longer spans the original)', () => {
+      const s = new MagicString('abcdef')
+
+      s.remove(3, 6)
+      assert.ok(s.hasChanged())
+    })
   })
 
   describe('replace', () => {


### PR DESCRIPTION
The local benchmark test results are as follows
**pr**
```
name                                            hz       rme  samples
---------------------------------------------------------------------
construct                               237,774.35    ±3.96%       97
append                               19,745,845.97    ±6.29%       61
indent                                   16,967.23    ±2.16%       74
generateMap (no edit)                     3,932.57    ±1.92%       99
generateMap (edit)                        3,804.54    ±6.04%       93
generateDecodedMap (no edit)              4,430.35    ±0.79%      100
generateDecodedMap (edit)                 4,457.77    ±0.38%      102
overwrite                                     3.69    ±3.05%       14
hasChanged (no edit)                 69,210,068.26    ±1.93%       90
hasChanged (edit)                    55,360,185.33    ±1.09%       91
```
**master**
```
name                                            hz       rme  samples
---------------------------------------------------------------------
construct                               215,561.52    ±5.72%       94
append                               19,458,321.51    ±6.03%       60
indent                                   16,922.44    ±2.86%       74
generateMap (no edit)                     3,887.83    ±2.38%       95
generateMap (edit)                        3,979.98    ±0.36%      101
generateDecodedMap (no edit)              4,184.33    ±0.78%      101
generateDecodedMap (edit)                 4,033.41    ±5.78%       97
overwrite                                     3.27   ±12.24%       13
hasChanged (no edit)                 50,909,675.81    ±1.42%       93
hasChanged (edit)                     8,589,731.38    ±2.62%       95
```