### PR TITLE
fix: keep the ignore-list hint and stored names when cloning

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -124,6 +124,8 @@ export default class Bundle {
       bundle.addSource({
         filename: source.filename,
         content: source.content.clone(),
+        ignoreList: source.ignoreList,
+        indentExclusionRanges: source.indentExclusionRanges,
         separator: source.separator,
       })
     })

--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -193,7 +193,11 @@ export default class MagicString {
    * Does what you'd expect.
    */
   clone(): this {
-    const cloned = new MagicString(this.original, { filename: this.filename, offset: this.offset })
+    const cloned = new MagicString(this.original, {
+      filename: this.filename,
+      ignoreList: this.ignoreList,
+      offset: this.offset,
+    })
 
     let originalChunk = this.firstChunk
     let clonedChunk = (cloned.firstChunk = cloned.lastSearchedChunk = originalChunk.clone())
@@ -224,6 +228,7 @@ export default class MagicString {
     }
 
     cloned.sourcemapLocations = new BitSet(this.sourcemapLocations)
+    cloned.storedNames = { ...this.storedNames }
 
     cloned.intro = this.intro
     cloned.outro = this.outro

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -108,6 +108,29 @@ describe('bundle', () => {
       assert.equal(b.toString(), '>>>abXXef\nghijkl<<<')
       assert.equal(clone.toString(), '>>>abcdef\nghijkl<<<')
     })
+    it('should clone the ignore-list hint', () => {
+      const b = new Bundle() as BundleInternals
+
+      b.addSource({ content: new MagicString('foo', { filename: 'foo.js' }), ignoreList: true })
+
+      const clone = b.clone() as BundleInternals
+
+      assert.strictEqual(clone.sources[0].ignoreList, true)
+      assert.deepEqual(clone.generateMap({ includeContent: false }).x_google_ignoreList, [0])
+    })
+
+    it('should clone indentExclusionRanges', () => {
+      const b = new Bundle() as BundleInternals
+
+      b.addSource({
+        content: new MagicString('foo', { filename: 'foo.js' }),
+        indentExclusionRanges: [1, 2],
+      })
+
+      const clone = b.clone() as BundleInternals
+
+      assert.deepEqual(clone.sources[0].indentExclusionRanges, [1, 2])
+    })
   })
 
   describe('generateMap', () => {

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -207,6 +207,40 @@ describe('magicString', () => {
 
       assert.equal(source.toString(), clone.toString())
     })
+
+    it('should clone the ignore-list hint', () => {
+      const source = new MagicString('abcdefghijkl', {
+        filename: 'foo.js',
+        ignoreList: true,
+      })
+
+      const clone = source.clone()
+
+      assert.equal(clone.ignoreList, true)
+      assert.deepEqual(clone.generateMap({ includeContent: false }).x_google_ignoreList, [0])
+    })
+
+    it('should clone stored names', () => {
+      const source = new MagicString('abcdefghijkl', { filename: 'foo.js' })
+
+      source.update(3, 9, 'XYZ', { storeName: true })
+
+      const clone = source.clone()
+
+      assert.notStrictEqual(source.storedNames, clone.storedNames)
+      assert.deepEqual(clone.generateMap({ includeContent: false }).names, ['defghi'])
+    })
+
+    it('should not share stored names with the clone', () => {
+      const source = new MagicString('abcdefghijkl', { filename: 'foo.js' })
+
+      source.update(3, 9, 'XYZ', { storeName: true })
+
+      const clone = source.clone()
+      clone.update(0, 3, 'ABC', { storeName: true })
+
+      assert.deepEqual(source.generateMap({ includeContent: false }).names, ['defghi'])
+    })
   })
 
   describe('generateMap', () => {


### PR DESCRIPTION
`clone()` drops state that the original carries into its sourcemap, in both `MagicString` and `Bundle`.

### `MagicString.clone()`

`MagicStringOptions` has four fields: `filename`, `ignoreList`, `indentExclusionRanges` and `offset`. `clone()` forwards `filename` and `offset` through the constructor and copies `indentExclusionRanges` by hand a few lines later. `ignoreList` is the one it never touches.

It also leaves `storedNames` at the fresh `{}` the constructor makes, so the names that `update(..., { storeName: true })` records never reach the clone.

| after `clone()` | original | clone before | clone after |
| --- | --- | --- | --- |
| `map.x_google_ignoreList` | `[0]` | `undefined` | `[0]` |
| `map.names` | `["foo"]` | `[]` | `["foo"]` |

`indentStr` is left alone on purpose: it is a lazy cache that `_ensureindentStr()` recomputes from `original`, and the clone gets the same `original`.

### `Bundle.clone()`

`addSource` treats a source as carrying four properties:

```js
['filename', 'ignoreList', 'indentExclusionRanges', 'separator']
```

`clone()` passed on `filename` and `separator` only, so a cloned bundle loses the per source ignore-list hint and its indent exclusion ranges.

Passing them explicitly does not break the existing fallback where `addSource` reads a missing property off `source.content`. I checked both paths: a hint set on the source descriptor and a hint set on the `MagicString` itself both survive the clone now, and a bundle with no hint still reports `undefined`.

### Tests

Neither `clone` block covered any of this, which is what made it worth checking. `MagicString`'s block already asserts `filename`, `indentExclusionRanges`, `sourcemapLocations`, `intro` and `outro` are carried over, so the intent is clear; these were simply missed.

Five tests added. Against master exactly four of them fail:

```
FAIL  Bundle > clone > should clone the ignore-list hint
      expected undefined to equal true
FAIL  Bundle > clone > should clone indentExclusionRanges
      expected undefined to deeply equal [ 1, 2 ]
FAIL  MagicString > clone > should clone the ignore-list hint
      expected undefined to equal true
FAIL  MagicString > clone > should clone stored names
      expected [] to deeply equal [ 'defghi' ]
```

The fifth, `should not share stored names with the clone`, passes both before and after. It guards the fix rather than the bug: `{ ...this.storedNames }` has to be a copy, so writing to the clone must not show up in the original.

Suite goes from 242 to 247 passing. `tsc --noEmit` is clean and `eslint` is clean.