### PR TITLE
fix: `hasChanged` reports a change when an edit spans a chunk boundary

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1156,7 +1156,12 @@ export default class MagicString {
     if (this.intro || this.outro)
       return true
 
-    let originalIndex = 0
+    // How much of `original` the chunks visited so far reproduce, which is not
+    // the same as how much of it they span: an overwrite covering several
+    // chunks stores the whole replacement on the first of them and empties the
+    // rest, so a chunk's content has to be compared against the original text
+    // at the offset it is emitted at rather than against its own start and end
+    let outputIndex = 0
     let chunk: Chunk | null = this.firstChunk
 
     while (chunk) {
@@ -1164,25 +1169,24 @@ export default class MagicString {
       if (chunk.intro || chunk.outro)
         return true
 
-      // Chunks must be in original order, otherwise content was moved
-      if (chunk.start !== originalIndex)
-        return true
+      if (!chunk.edited && chunk.start === outputIndex) {
+        // An untouched chunk still at its original offset reproduces the
+        // original exactly, so it needs no comparison
+        outputIndex = chunk.end
+      }
+      else {
+        // `startsWith` with an offset compares in place, where slicing the
+        // original first would allocate on every edited chunk
+        if (!this.original.startsWith(chunk.content, outputIndex))
+          return true
 
-      // For edited chunks, check if content actually differs from original;
-      // compare lengths first so a slice is only allocated when they match
-      if (
-        chunk.edited
-        && (chunk.content.length !== chunk.end - chunk.start
-          || chunk.content !== this.original.slice(chunk.start, chunk.end))
-      ) {
-        return true
+        outputIndex += chunk.content.length
       }
 
-      originalIndex = chunk.end
       chunk = chunk.next
     }
 
-    return originalIndex !== this.original.length
+    return outputIndex !== this.original.length
   }
 
   /** @internal */

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1904,6 +1904,27 @@ describe('magicString', () => {
       assert.ok(!t.hasChanged())
     })
 
+    it('should return false when an edit spanning several chunks restores the original', () => {
+      // `appendLeft` splits the chunk at 3, so the overwrite that follows
+      // covers two chunks: the whole replacement lands on the first one and
+      // the second is emptied
+      const s = new MagicString('abcdefghij')
+
+      s.appendLeft(3, '')
+      s.overwrite(0, 5, 'abcde')
+      assert.equal(s.toString(), 'abcdefghij')
+      assert.ok(!s.hasChanged())
+
+      // the same thing without an explicit split: the second overwrite spans
+      // the chunk boundary left behind by the first
+      const t = new MagicString('abcdefghij')
+
+      t.overwrite(2, 6, 'cdef')
+      t.overwrite(2, 7, 'cdefg')
+      assert.equal(t.toString(), 'abcdefghij')
+      assert.ok(!t.hasChanged())
+    })
+
     it('should return false after reset reverts the edits', () => {
       const s = new MagicString('abcdef')
 


### PR DESCRIPTION
Fixes #332.

#328 replaced `original !== toString()` with a walk over the chunk list. The walk compares each edited chunk against `original.slice(chunk.start, chunk.end)`, which assumes a chunk's content is the replacement for its own range.

That assumption breaks when an overwrite spans more than one chunk. The whole replacement is stored on the first chunk and the rest are emptied, so the first chunk's content is longer than its own range and the comparison fails even though the concatenation is unchanged:

```js
const s = new MagicString('abcdefghij')
s.appendLeft(3, '')          // splits the chunk at 3
s.overwrite(0, 5, 'abcde')   // spans the split

s.toString()   // 'abcdefghij'
s.hasChanged() // true on master, false on 1.2.1
```

The split does not have to be explicit. Two overlapping overwrites create one on their own:

```js
const t = new MagicString('abcdefghij')
t.overwrite(2, 6, 'cdef')
t.overwrite(2, 7, 'cdefg')

t.toString()   // 'abcdefghij'
t.hasChanged() // true on master, false on 1.2.1
```

This tracks how much of `original` the chunks visited so far reproduce rather than how much of it they span, and compares each chunk's content against the original text at the offset it is actually emitted at. An untouched chunk still sitting at its original offset keeps the cheap path and is not compared at all, so the optimisation still avoids building the string.

The `chunk.start !== originalIndex` check is dropped because it is subsumed by that comparison: a moved chunk no longer matches the original text at the offset it is emitted at. The existing `should return true when content is only moved` test still passes.

Verified differentially against the old `original !== toString()` over 20,880 random operation sequences drawn from `remove`, `overwrite`, `update`, `reset`, `move`, `indent` and the four append and prepend methods, on a fixed seed. 775 of them disagree on master, every one a false positive where the string is unchanged and `hasChanged()` returns true. None disagree with this change.

The added test fails on master and passes here. `pnpm test` is clean (243), as are lint and typecheck.

On the benchmark cases #328 added, node v24.16.0:

| | master | this branch |
|---|---|---|
| `hasChanged (no edit)` | 53,269,421 ops/s | 53,840,040 ops/s |
| `hasChanged (edit)` | 41,801,099 ops/s | 13,294,098 ops/s |

The unchanged path, which is the one that gates work in a bundler, is unaffected. The already-edited path is about three times slower, because deciding correctly needs the content compared rather than a chunk's length checked against its own span, and a length mismatch on a single chunk no longer proves anything. In absolute terms that is roughly 24ns against 76ns per call, on a path where the answer is `true` and the caller is about to regenerate output anyway. I would rather put that in front of you than quietly trade it, so if you would prefer a different balance here I am happy to rework it.
