### PR TITLE
fix: trim the separators between sources

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -338,15 +338,23 @@ export default class Bundle {
     this.intro = this.intro.replace(rx, '')
 
     if (!this.intro) {
-      let source
-      let i = 0
+      for (let i = 0; i < this.sources.length; i += 1) {
+        const source = this.sources[i]
 
-      do {
-        source = this.sources[i++]
-        if (!source) {
+        if (i > 0) {
+          // mirrors toString(): every source but the first is preceded by a separator
+          const separator = source.separator !== undefined ? source.separator : this.separator
+          source.separator = separator.replace(rx, '')
+
+          if (source.separator) {
+            break
+          }
+        }
+
+        if (source.content.trimStartAborted(charType)) {
           break
         }
-      } while (!source.content.trimStartAborted(charType))
+      }
     }
 
     return this
@@ -355,16 +363,25 @@ export default class Bundle {
   trimEnd(charType?: string): this {
     const rx = new RegExp(`${charType || '\\s'}+$`)
 
-    let source
-    let i = this.sources.length - 1
+    for (let i = this.sources.length - 1; i >= 0; i -= 1) {
+      const source = this.sources[i]
 
-    do {
-      source = this.sources[i--]
-      if (!source) {
-        this.intro = this.intro.replace(rx, '')
-        break
+      if (source.content.trimEndAborted(charType)) {
+        return this
       }
-    } while (!source.content.trimEndAborted(charType))
+
+      if (i > 0) {
+        // mirrors toString(): every source but the first is preceded by a separator
+        const separator = source.separator !== undefined ? source.separator : this.separator
+        source.separator = separator.replace(rx, '')
+
+        if (source.separator) {
+          return this
+        }
+      }
+    }
+
+    this.intro = this.intro.replace(rx, '')
 
     return this
   }

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -837,6 +837,46 @@ describe('bundle', () => {
       const b = new Bundle()
       assert.strictEqual(b.trim(), b)
     })
+
+    it('should trim a whitespace separator', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('   ') })
+      b.addSource({ content: new MagicString('   abc') })
+
+      b.trimStart()
+      assert.equal(b.toString(), 'abc')
+    })
+
+    it('should trim a whitespace separator from the end', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('abc   ') })
+      b.addSource({ content: new MagicString('   ') })
+
+      b.trimEnd()
+      assert.equal(b.toString(), 'abc')
+    })
+
+    it('should empty a bundle of whitespace sources', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('  ') })
+      b.addSource({ content: new MagicString('  ') })
+
+      b.trim()
+      assert.equal(b.toString(), '')
+    })
+
+    it('should stop at a separator that is not whitespace', () => {
+      const b = new Bundle({ separator: ';' })
+
+      b.addSource({ content: new MagicString('   ') })
+      b.addSource({ content: new MagicString('   abc') })
+
+      b.trimStart()
+      assert.equal(b.toString(), ';   abc')
+    })
   })
 
   describe('toString', () => {


### PR DESCRIPTION
`trimStart` and `trimEnd` walk from one source to the next, but never look at the separator that `toString()` puts between them. Two things fall out of that.

**The separator survives a trim that should have removed it.** Once the leading source is fully whitespace, the next thing in the output is its separator, and the walk skips straight over it to the following source:

| bundle | `toString()` | after trim, before | after trim, now |
| --- | --- | --- | --- |
| `"   "` then `"   abc"`, `trimStart()` | `"   \n   abc"` | `"\nabc"` | `"abc"` |
| `"abc   "` then `"   "`, `trimEnd()` | `"abc   \n   "` | `"abc\n"` | `"abc"` |
| `"  "` then `"  "`, `trim()` | `"  \n  "` | `"\n"` | `""` |

**And the trim keeps going past a separator it should have stopped at.** With `separator: ';'`, the output is `"   ;   abc"`. Trimming whitespace from the start should take the three leading spaces and stop at the semicolon, but the old walk carried on into the next source and removed the spaces after the semicolon too, which are not at the start any more:

```
before: '   ;   abc'  ->  ';abc'
now:    '   ;   abc'  ->  ';   abc'
```

Both loops now give the separator its turn in the walk, so it is trimmed when it matches `charType` and stops the trim when it does not. This is the same shape as #322, #323 and #327: a `Bundle` method that mirrors `toString()` everywhere except the separator.

### Tests

The `trim` block had three tests and none of them had a source that trims away completely, which is why this stayed hidden.

Four tests added. Against master all four fail:

```
expected '\nabc'  to equal 'abc'
expected 'abc\n'  to equal 'abc'
expected '\n'     to equal ''
expected ';abc'   to equal ';   abc'
```

The two existing cases where the first source has real content (`should trim bundle` and `should handle funky edge cases`) are untouched, since the walk still stops at the first source that does not trim away.

Suite goes from 248 to 252 passing. `tsc --noEmit` is clean and `eslint` is clean.