### PR TITLE
fix: guess the most common indentation in a bundle

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -246,7 +246,7 @@ export default class Bundle {
 
     return (
       Object.keys(indentStringCounts).sort((a, b) => {
-        return indentStringCounts[a] - indentStringCounts[b]
+        return indentStringCounts[b] - indentStringCounts[a]
       })[0] || '\t'
     )
   }

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -640,6 +640,26 @@ describe('bundle', () => {
       assert.equal(b.toString(), '  abcdef\n  ghijkl\n    mnopqr')
     })
 
+    it('should guess the most common indentation', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('    abc') })
+      b.addSource({ content: new MagicString('    def') })
+      b.addSource({ content: new MagicString('  ghi') })
+
+      assert.equal(b.getIndentString(), '    ')
+    })
+
+    it('should not let a single source outvote the rest', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('  abc') })
+      b.addSource({ content: new MagicString('  def') })
+      b.addSource({ content: new MagicString('      ghi') })
+
+      assert.equal(b.getIndentString(), '  ')
+    })
+
     it('should respect indent exclusion ranges', () => {
       const b = new Bundle()
 


### PR DESCRIPTION
`Bundle#getIndentString` builds `indentStringCounts`, a map of indent string to how many sources use it, and then picks a winner like this:

```js
Object.keys(indentStringCounts).sort((a, b) => {
  return indentStringCounts[a] - indentStringCounts[b]
})[0] || '\t'
```

That sorts ascending, so `[0]` is the **least** used indent string. The winner is the odd one out.

| sources | guess before | guess now |
| --- | --- | --- |
| two tab indented, one two-space | two spaces | tab |
| two two-space, one tab | tab | two spaces |
| two four-space, one two-space | two spaces | four spaces |

`indent()` with no argument calls this, so a bundle of mostly tab indented sources gets indented with the spaces of a single outlier.

### Why the most used one is what was meant

- The map is a set of counts. Counting is only worth doing to find the most common value; the least common needs no tally beyond presence.
- `guessIndent` already decides this way one level down: "More lines tabbed than spaced? Assume tabs".
- #3 asked for sources with no indented lines to be skipped, because those sources defaulted to `\t` and left tabs "over-represented", which made the bundle "incorrectly assume that tabs should be used". Over-representation can only pick the wrong winner if the higher count wins. Under the current sort, inflating the tab count would push tabs further from being chosen, and the report would not make sense.
- The fix for #3 (9ce76a3) only added the `indentStr === null` skip and never touched this sort, and the sort has read the same way since the first version of the file in 2015.

This is a behaviour change, so it is worth saying plainly: bundles that mix indent styles will now be indented with the dominant one rather than the rarest.

### Tests

`Bundle#getIndentString` has no tests of its own. The nearest one, `should ignore non-indented sources when guessing indentation`, leaves a single indent string standing, so the sort direction never mattered there and it is unaffected.

Two tests added, both fail against master:

```
expected '  '      to equal '    '
expected '      '  to equal '  '
```

Ties are unchanged: equal counts still compare as 0, and the sort is stable, so insertion order still decides.

Suite goes from 252 to 254 passing. `tsc --noEmit` is clean and `eslint` is clean.