### PR TITLE
fix: handle empty matches in `replace` and `replaceAll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ The differences from [`String.replace`](<(https://developer.mozilla.org/en-US/do
 
 - It will always match against the **original string**
 - It mutates the magic string state (use `.clone()` to be immutable)
+- A zero-length match spans no characters, so there is nothing to overwrite - the
+  substitution is inserted at the matched position, as if by `s.appendRight(index, substitution)`
 
 ### s.replaceAll( regexpOrString, substitution )
 

--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1214,35 +1214,40 @@ export default class MagicString {
         return replacement(match[0], ...match.slice(1), match.index, str, match.groups)
       }
     }
-    function matchAll(re: RegExp, str: string): RegExpExecArray[] {
-      const matches = []
-      while (true) {
-        const match = re.exec(str)
-        if (!match)
-          break
+    const replaceMatch = (match: RegExpMatchArray): void => {
+      if (match.index == null)
+        return
 
-        matches.push(match)
+      const replacement = getReplacement(match, this.original)
+      if (replacement === match[0])
+        return
+
+      if (match[0].length === 0) {
+        // a zero-length match spans no characters, so there is no range to
+        // overwrite - the replacement is an insertion at the matched position,
+        // which is what `String.prototype.replace` does for an empty match
+        this.appendRight(match.index, replacement)
       }
-      return matches
+      else {
+        this.overwrite(match.index, match.index + match[0].length, replacement)
+      }
     }
+
     if (searchValue.global) {
-      const matches = matchAll(searchValue, this.original)
-      matches.forEach((match) => {
-        if (match.index != null) {
-          const replacement = getReplacement(match, this.original)
-          if (replacement !== match[0]) {
-            this.overwrite(match.index, match.index + match[0].length, replacement)
-          }
-        }
-      })
+      // `String.prototype.replace` starts a global regexp from the beginning of
+      // the string, so reset `lastIndex` - a regexp that has already been used
+      // would otherwise resume from wherever it stopped and skip earlier matches.
+      // `matchAll` also steps over a zero-length match, where `exec` in a loop
+      // would keep rematching it at an unmoving `lastIndex` and never terminate.
+      searchValue.lastIndex = 0
+      for (const match of this.original.matchAll(searchValue)) {
+        replaceMatch(match)
+      }
     }
     else {
       const match = this.original.match(searchValue)
-      if (match && match.index != null) {
-        const replacement = getReplacement(match, this.original)
-        if (replacement !== match[0]) {
-          this.overwrite(match.index, match.index + match[0].length, replacement)
-        }
+      if (match) {
+        replaceMatch(match)
       }
     }
     return this
@@ -1258,7 +1263,15 @@ export default class MagicString {
         replacement = replacement(string, index, original)
       }
       if (string !== replacement) {
-        this.overwrite(index, index + string.length, replacement)
+        if (string.length === 0) {
+          // an empty search string matches the empty range at the start of the
+          // string, which has no characters to overwrite - the replacement is an
+          // insertion there, as it is for `String.prototype.replace`
+          this.appendRight(index, replacement)
+        }
+        else {
+          this.overwrite(index, index + string.length, replacement)
+        }
       }
     }
 
@@ -1280,6 +1293,21 @@ export default class MagicString {
   _replaceAllString(string: string, replacement: string | ReplacementFunction): this {
     const { original } = this
     const stringLength = string.length
+
+    // an empty search string matches the empty range before every character plus
+    // one at the end, and `indexOf` clamps its start index to the string length,
+    // so it can neither find those ranges nor ever report -1 - step through them
+    if (stringLength === 0) {
+      for (let index = 0; index <= original.length; index += 1) {
+        const _replacement
+          = typeof replacement === 'function' ? replacement('', index, original) : replacement
+        if (_replacement !== '')
+          this.appendRight(index, _replacement)
+      }
+
+      return this
+    }
+
     for (
       let index = original.indexOf(string);
       index !== -1;

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -2102,6 +2102,27 @@ describe('magicString', () => {
 
       assert.strictEqual(s.firstChunk, s.lastChunk)
     })
+
+    it('should insert at a zero-length match instead of overwriting nothing', () => {
+      // an empty match spans no characters, so there is no range to overwrite -
+      // `String.prototype.replace` inserts at the matched position
+      assert.strictEqual(new MagicString('abc').replace(/x?/, 'Y').toString(), 'Yabc')
+      assert.strictEqual(new MagicString('abc').replace('', 'X').toString(), 'Xabc')
+    })
+
+    it('should terminate on a global regexp that matches the empty string', () => {
+      assert.strictEqual(new MagicString('bab').replace(/a*/g, 'X').toString(), 'XbXXbX')
+      assert.strictEqual(new MagicString('a b').replace(/\s*/g, '_').toString(), '_a__b_')
+      assert.strictEqual(new MagicString('axb').replace(/x?/g, 'Y').toString(), 'YaYYbY')
+    })
+
+    it('should start a global regexp from the beginning of the string', () => {
+      const re = /o/g
+      re.exec('foo') // leaves lastIndex at 2
+
+      assert.strictEqual(new MagicString('foo').replace(re, 'X').toString(), 'fXX')
+      assert.strictEqual(re.lastIndex, 0)
+    })
   })
 
   describe('replaceAll', () => {
@@ -2182,6 +2203,53 @@ describe('magicString', () => {
       const s1 = s.clone()
       assert.strictEqual(s1.slice(), 'ello world')
       assert.equal(s1.move(0, 1, 2).slice(0), 'elo world')
+    })
+
+    it('should insert at every zero-length match', () => {
+      assert.strictEqual(
+        new MagicString('a\nb\nc').replaceAll(/^/gm, '// ').toString(),
+        '// a\n// b\n// c',
+      )
+      assert.strictEqual(new MagicString('a\nb').replaceAll(/$/gm, ';').toString(), 'a;\nb;')
+      assert.strictEqual(new MagicString('ab cd').replaceAll(/\b/g, '|').toString(), '|ab| |cd|')
+      assert.strictEqual(new MagicString('abc').replaceAll(/x*/g, '-').toString(), '-a-b-c-')
+      assert.strictEqual(new MagicString('abc').replaceAll('', '-').toString(), '-a-b-c-')
+    })
+
+    it('should step over a whole code point for a unicode-aware regexp', () => {
+      // without the `u` flag the surrogate halves are matched between, as they are
+      // by `String.prototype.replaceAll`
+      const emoji = '\u{1F600}'
+
+      assert.strictEqual(
+        new MagicString(`a${emoji}b`).replaceAll(/x*/gu, '.').toString(),
+        `.a.${emoji}.b.`,
+      )
+      assert.strictEqual(
+        new MagicString(`a${emoji}b`).replaceAll(/x*/g, '.').toString(),
+        `.a.${emoji[0]}.${emoji[1]}.b.`,
+      )
+    })
+
+    it('should report the index of every empty-string match to a replacer', () => {
+      const indexes: number[] = []
+      const s = new MagicString('ab').replaceAll('', (_match, index) => {
+        indexes.push(index)
+        return `<${index}>`
+      })
+
+      assert.strictEqual(s.toString(), '<0>a<1>b<2>')
+      assert.deepEqual(indexes, [0, 1, 2])
+    })
+
+    it('should leave the original alone when an empty match is replaced by itself', () => {
+      const s = new MagicString('abc')
+
+      s.replaceAll(/x*/g, '')
+      s.replaceAll('', '')
+
+      assert.strictEqual(s.toString(), 'abc')
+      assert.strictEqual(s.hasChanged(), false)
     })
   })
 })


### PR DESCRIPTION
### The bug

`_replaceRegexp` collected matches by driving `exec` in a `while (true)` loop:

```js
while (true) {
  const match = re.exec(str)
  if (!match) break
  matches.push(match)
}
```

A zero-length match does not move `lastIndex`, so the loop rematches at the same
index forever. Any global regexp that can match the empty string hangs and then
runs the process out of memory:

```js
new MagicString('a\nb\nc').replaceAll(/^/gm, '// ') // OOM
```

`/^/gm`, `/$/gm`, `/\b/g`, `/\s*/g`, `/x?/g` and `/a*/g` are all affected, so
commenting out every line — a fairly ordinary thing to reach for — cannot be
done today.

The same loop never reset `lastIndex`, so a regexp that has already been used
resumes from wherever it stopped and silently skips earlier matches, where
`String.prototype.replace` always starts from the beginning of the string:

```js
const re = /o/g
re.exec('foo')                                   // lastIndex is now 2

'foo'.replaceAll(re, 'X')                        // "fXX"
new MagicString('foo').replaceAll(re, 'X')       // "foX"  <- 'fo' skipped
```

### The fix

`String.prototype.matchAll` is used instead. It steps over an empty match, and
it does so by a whole code point when the regexp is unicode-aware, which a
hand-rolled `lastIndex++` would get wrong for astral characters. `lastIndex` is
reset first, since `matchAll` starts from the regexp's own `lastIndex`.

That leaves the empty match reaching `overwrite`, which rejects a zero-length
range. An empty match spans no characters, so there is no range to overwrite —
the substitution is an *insertion* at the matched position, which is exactly what
`String.prototype.replace` does with one. It is applied with `appendRight`, so it
belongs to the range starting at that index, the same way an overwrite does.

The string overloads had the same gap and are fixed alongside: `replace('', x)`
threw, and `replaceAll('', x)` could not terminate because `indexOf` clamps its
start index to the string length and so never reports `-1`.

Every case below now agrees with the built-in method:

| | `String.prototype` | before | after |
| --- | --- | --- | --- |
| `replaceAll(/a*/g, 'X')` on `'bab'` | `'XbXXbX'` | OOM | `'XbXXbX'` |
| `replaceAll(/^/gm, '// ')` on `'a\nb'` | `'// a\n// b'` | OOM | `'// a\n// b'` |
| `replaceAll(/\b/g, '\|')` on `'ab cd'` | `'\|ab\| \|cd\|'` | OOM | `'\|ab\| \|cd\|'` |
| `replace(/x?/, 'Y')` on `'abc'` | `'Yabc'` | throws | `'Yabc'` |
| `replaceAll(stale /o/g, 'X')` on `'foo'` | `'fXX'` | `'foX'` | `'fXX'` |
| `replace('', 'X')` on `'abc'` | `'Xabc'` | throws | `'Xabc'` |
| `replaceAll('', 'X')` on `'abc'` | `'XaXbXcX'` | throws | `'XaXbXcX'` |
| `replaceAll(/x*/gu, '.')` on `'a😀b'` | `'.a.😀.b.'` | OOM | `'.a.😀.b.'` |

### Notes

- README documents only two differences from `String.replace`, and neither covers
  empty matches, so this brings the code in line with what is already documented.
  The one behaviour worth stating — that a zero-length match inserts — is added there.
- The change is additive. I diffed 2406 combinations of source string, string and
  regexp pattern, string and function substitution, `replace`/`replaceAll` and
  `offset` against `master`: **zero** differences outside the empty-match cases
  above, which previously hung or threw.
- The existing 252 tests pass unchanged; 7 tests are added. `pnpm run lint`,
  `pnpm test` and both `typecheck` projects are clean.
- `appendRight` vs `prependRight` for the insertion is the one judgement call
  here. It is invisible unless something else is inserted at the same index, and
  `appendRight` keeps the replacement part of the range it replaced, the way
  `overwrite` does. Happy to switch it if you would rather it went the other way.

Closes #336.
