### PR TITLE
fix: clamp negative indices below -length instead of wrapping repeatedly

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -608,8 +608,10 @@ export default class MagicString {
     }
 
     if (this.original.length !== 0) {
-      while (start < 0) start += this.original.length
-      while (end < 0) end += this.original.length
+      if (start < 0)
+        start = Math.max(0, start + this.original.length)
+      if (end < 0)
+        end = Math.max(0, end + this.original.length)
     }
 
     if (start < 0) {
@@ -764,8 +766,10 @@ export default class MagicString {
     end = end + this.offset
 
     if (this.original.length !== 0) {
-      while (start < 0) start += this.original.length
-      while (end < 0) end += this.original.length
+      if (start < 0)
+        start = Math.max(0, start + this.original.length)
+      if (end < 0)
+        end = Math.max(0, end + this.original.length)
     }
 
     if (start === end)
@@ -807,8 +811,10 @@ export default class MagicString {
     end = end + this.offset
 
     if (this.original.length !== 0) {
-      while (start < 0) start += this.original.length
-      while (end < 0) end += this.original.length
+      if (start < 0)
+        start = Math.max(0, start + this.original.length)
+      if (end < 0)
+        end = Math.max(0, end + this.original.length)
     }
 
     if (start === end)
@@ -902,8 +908,10 @@ export default class MagicString {
     end = end + this.offset
 
     if (this.original.length !== 0) {
-      while (start < 0) start += this.original.length
-      while (end < 0) end += this.original.length
+      if (start < 0)
+        start = Math.max(0, start + this.original.length)
+      if (end < 0)
+        end = Math.max(0, end + this.original.length)
     }
 
     let result = ''

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1611,6 +1611,11 @@ describe('magicString', () => {
       const sUpdate = new MagicString('problems = 99')
       sUpdate.update(-100, 5, 'solution')
       assert.equal(sUpdate.toString(), 'solutionems = 99')
+
+      const sReset = new MagicString('problems = 99')
+      sReset.update(0, 5, 'XXXXX')
+      sReset.reset(-100, 5)
+      assert.equal(sReset.toString(), 'problems = 99')
     })
 
     it('includes inserted characters, respecting insertion direction', () => {

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1599,6 +1599,20 @@ describe('magicString', () => {
       assert.equal(s.slice(0, -3), 'abcdefghi')
     })
 
+    it('clamps negative indices below -length instead of wrapping repeatedly', () => {
+      const s = new MagicString('problems = 99')
+      assert.equal(s.slice(-100, 5), 'probl')
+      assert.equal(s.slice(-100, -1), 'problems = 9')
+
+      const sRemove = new MagicString('problems = 99')
+      sRemove.remove(-100, 5)
+      assert.equal(sRemove.toString(), 'ems = 99')
+
+      const sUpdate = new MagicString('problems = 99')
+      sUpdate.update(-100, 5, 'solution')
+      assert.equal(sUpdate.toString(), 'solutionems = 99')
+    })
+
     it('includes inserted characters, respecting insertion direction', () => {
       const s = new MagicString('abefij')
 


### PR DESCRIPTION
Fixes #319.

When normalizing negative indices in `update`, `remove`, `reset`, and `slice`, indices below `-length` previously looped with `while (start < 0) start += length`, causing multiple wraps around the string and resolving to arbitrary in-bounds positions instead of matching `String.prototype.slice` semantics.

### Changes
- Replaced `while (start < 0) start += length` with `if (start < 0) start = Math.max(0, start + length)` across index resolution paths.
- Added tests verifying behavior when indices are less than `-length`.