### PR TITLE
perf: avoid split() when locating lines

### DIFF
--- a/src/utils/Mappings.ts
+++ b/src/utils/Mappings.ts
@@ -136,16 +136,16 @@ export default class Mappings {
     if (!str)
       return
 
-    const lines = str.split('\n')
+    const lastNewline = str.lastIndexOf('\n')
 
-    if (lines.length > 1) {
-      for (let i = 0; i < lines.length - 1; i++) {
+    if (lastNewline !== -1) {
+      for (let i = str.indexOf('\n'); i !== -1; i = str.indexOf('\n', i + 1)) {
         this.generatedCodeLine++
         this.raw[this.generatedCodeLine] = this.rawSegments = []
       }
       this.generatedCodeColumn = 0
     }
 
-    this.generatedCodeColumn += lines[lines.length - 1].length
+    this.generatedCodeColumn += str.length - lastNewline - 1
   }
 }

--- a/src/utils/getLocator.ts
+++ b/src/utils/getLocator.ts
@@ -4,12 +4,10 @@ export interface SourceLocation {
 }
 
 export default function getLocator(source: string): (index: number) => SourceLocation {
-  const originalLines = source.split('\n')
-  const lineOffsets = []
+  const lineOffsets = [0]
 
-  for (let i = 0, pos = 0; i < originalLines.length; i++) {
-    lineOffsets.push(pos)
-    pos += originalLines[i].length + 1
+  for (let i = source.indexOf('\n'); i !== -1; i = source.indexOf('\n', i + 1)) {
+    lineOffsets.push(i + 1)
   }
 
   return function locate(index: number): SourceLocation {


### PR DESCRIPTION
`getLocator` split the whole source into an array of lines just to compute line offsets, and `Mappings.advance` split every intro, outro and edit to count newlines. Both now use `indexOf` and keep only the offsets and counts. Output is unchanged; `pnpm bench` on this machine moves `generateDecodedMap (no edit)` from 2,269 to 2,426 hz, the rest is within noise.
