### PR TITLE
fix: expand `$` substitutions in `replace` as `String.prototype` does

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -48,6 +48,94 @@ const warned = {
   storeName: false,
 }
 
+/**
+ * Expands the `$` substitution patterns that `String.prototype.replace` accepts
+ * in a string replacement.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+ *
+ * `captures` holds the capture groups in order, so `captures[0]` is `$1`.
+ * `namedCaptures` is `undefined` when the pattern has no named groups, and
+ * `$<name>` is then literal text - which is also the case for a string search
+ * value, where there are no groups of either kind.
+ */
+function expandReplacement(
+  replacement: string,
+  matched: string,
+  position: number,
+  str: string,
+  captures: (string | undefined)[],
+  namedCaptures: Record<string, string | undefined> | undefined,
+): string {
+  if (!replacement.includes('$'))
+    return replacement
+
+  let result = ''
+  let index = 0
+
+  while (index < replacement.length) {
+    const dollar = replacement.indexOf('$', index)
+    if (dollar === -1) {
+      result += replacement.slice(index)
+      break
+    }
+
+    result += replacement.slice(index, dollar)
+
+    const char = replacement[dollar + 1]
+    // a `$` that introduces nothing recognisable stands for itself, so consume
+    // only the `$` and reconsider what follows as text
+    let expansion = '$'
+    let consumed = 1
+
+    if (char === '$') {
+      consumed = 2
+    }
+    else if (char === '&') {
+      expansion = matched
+      consumed = 2
+    }
+    else if (char === '`') {
+      expansion = str.slice(0, position)
+      consumed = 2
+    }
+    else if (char === '\'') {
+      expansion = str.slice(position + matched.length)
+      consumed = 2
+    }
+    else if (char === '<' && namedCaptures !== undefined) {
+      const close = replacement.indexOf('>', dollar + 2)
+      if (close !== -1) {
+        // an unknown group name expands to nothing rather than staying literal
+        expansion = namedCaptures[replacement.slice(dollar + 2, close)] ?? ''
+        consumed = close + 1 - dollar
+      }
+    }
+    else if (char >= '0' && char <= '9') {
+      const second = replacement[dollar + 2]
+      const double = second >= '0' && second <= '9' ? Number(char + second) : Number.NaN
+      const single = Number(char)
+
+      // `$nn` only wins over `$n` when it names a group that exists, so `$12`
+      // is group 12 given twelve groups and group 1 followed by "2" given one.
+      // `$0` names no group and is literal, as is any index past the last group
+      if (double >= 1 && double <= captures.length) {
+        expansion = captures[double - 1] ?? ''
+        consumed = 3
+      }
+      else if (single >= 1 && single <= captures.length) {
+        // a group that did not participate in the match expands to nothing
+        expansion = captures[single - 1] ?? ''
+        consumed = 2
+      }
+    }
+
+    result += expansion
+    index = dollar + consumed
+  }
+
+  return result
+}
+
 export default class MagicString {
   declare original: string
   /** @internal */
@@ -1206,17 +1294,14 @@ export default class MagicString {
   _replaceRegexp(searchValue: RegExp, replacement: string | ReplacementFunction): this {
     function getReplacement(match: RegExpMatchArray, str: string): string {
       if (typeof replacement === 'string') {
-        return replacement.replace(/\$(\$|&|\d+)/g, (_: string, i: string) => {
-          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
-          if (i === '$')
-            return '$'
-          if (i === '&')
-            return match[0]
-          const num = +i
-          if (num < match.length)
-            return match[+i]
-          return `$${i}`
-        })
+        return expandReplacement(
+          replacement,
+          match[0],
+          match.index,
+          str,
+          match.slice(1),
+          match.groups,
+        )
       }
       else {
         return replacement(match[0], ...match.slice(1), match.index, str, match.groups)
@@ -1270,6 +1355,9 @@ export default class MagicString {
       if (typeof replacement === 'function') {
         replacement = replacement(string, index, original)
       }
+      else {
+        replacement = expandReplacement(replacement, string, index, original, [], undefined)
+      }
       if (string !== replacement) {
         if (string.length === 0) {
           // an empty search string matches the empty range at the start of the
@@ -1308,7 +1396,9 @@ export default class MagicString {
     if (stringLength === 0) {
       for (let index = 0; index <= original.length; index += 1) {
         const _replacement
-          = typeof replacement === 'function' ? replacement('', index, original) : replacement
+          = typeof replacement === 'function'
+            ? replacement('', index, original)
+            : expandReplacement(replacement, '', index, original, [], undefined)
         if (_replacement !== '')
           this.appendRight(index, _replacement)
       }
@@ -1323,7 +1413,9 @@ export default class MagicString {
     ) {
       const previous = original.slice(index, index + stringLength)
       const _replacement
-        = typeof replacement === 'function' ? replacement(previous, index, original) : replacement
+        = typeof replacement === 'function'
+          ? replacement(previous, index, original)
+          : expandReplacement(replacement, previous, index, original, [], undefined)
       if (previous !== _replacement)
         this.overwrite(index, index + stringLength, _replacement)
     }

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -2055,11 +2055,14 @@ describe('magicString', () => {
     })
 
     it('works with global regex replace', () => {
-      const s = new MagicString('1 2 3 4 a b c')
+      const code = '1 2 3 4 a b c'
+      const s = new MagicString(code)
 
       s.replace(/(\d)/g, 'xx$1$10')
 
-      assert.strictEqual(s.toString(), 'xx1$10 xx2$10 xx3$10 xx4$10 a b c')
+      // there is no tenth group, so `$10` is group 1 followed by a literal "0"
+      assert.strictEqual(s.toString(), 'xx110 xx220 xx330 xx440 a b c')
+      assert.strictEqual(s.toString(), code.replace(/(\d)/g, 'xx$1$10'))
     })
 
     it('works with global regex replace $$', () => {
@@ -2068,6 +2071,150 @@ describe('magicString', () => {
       s.replace(/(\d)/g, '$$')
 
       assert.strictEqual(s.toString(), '$ $ $ $ a b c')
+    })
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+    describe('substitution patterns', () => {
+      it('expands $& to the matched substring', () => {
+        assert.strictEqual(new MagicString('abcabc').replace(/b/, '[$&]').toString(), 'a[b]cabc')
+      })
+
+      it('expands $` and $\' to the text around the match', () => {
+        assert.strictEqual(new MagicString('abcabc').replace(/b/, '$`').toString(), 'aacabc')
+        assert.strictEqual(new MagicString('abcabc').replace(/b/, '$\'').toString(), 'acabccabc')
+      })
+
+      it('expands $<name> for a named capture group', () => {
+        const s = new MagicString('abcabc')
+
+        s.replace(/(?<first>a)(?<second>b)/, '$<second>$<first>')
+
+        assert.strictEqual(s.toString(), 'bacabc')
+      })
+
+      it('expands an unknown group name to nothing', () => {
+        assert.strictEqual(
+          new MagicString('abcabc').replace(/(?<first>a)/, '[$<nope>]').toString(),
+          '[]bcabc',
+        )
+      })
+
+      it('leaves $<name> literal when the pattern has no named groups', () => {
+        assert.strictEqual(
+          new MagicString('abcabc').replace(/b/, '$<first>').toString(),
+          'a$<first>cabc',
+        )
+      })
+
+      it('expands a group that did not participate in the match to nothing', () => {
+        assert.strictEqual(new MagicString('ac').replace(/a(b)?/, '[$1]').toString(), '[]c')
+      })
+
+      it('leaves $0 literal, since it names no group', () => {
+        assert.strictEqual(new MagicString('abcabc').replace(/(a)/, '[$0]').toString(), '[$0]bcabc')
+      })
+
+      it('prefers $nn over $n only when that group exists', () => {
+        // one group: `$12` is group 1 followed by a literal "2"
+        assert.strictEqual(new MagicString('ab').replace(/(a)/, '[$12]').toString(), '[a2]b')
+        // two groups: `$01` is group 1
+        assert.strictEqual(new MagicString('ab').replace(/(a)(b)/, '[$01]').toString(), '[a]')
+        // `$00` names no group at all
+        assert.strictEqual(new MagicString('ab').replace(/(a)(b)/, '[$00]').toString(), '[$00]')
+      })
+
+      it('leaves a dollar sign that introduces nothing recognisable alone', () => {
+        assert.strictEqual(new MagicString('abcabc').replace(/b/, '$').toString(), 'a$cabc')
+        assert.strictEqual(new MagicString('abcabc').replace(/b/, '$z').toString(), 'a$zcabc')
+      })
+
+      it('expands $$, $& and the surrounding text for a string search value', () => {
+        assert.strictEqual(new MagicString('abcabc').replace('b', '$$').toString(), 'a$cabc')
+        assert.strictEqual(new MagicString('abcabc').replace('b', '[$&]').toString(), 'a[b]cabc')
+        assert.strictEqual(new MagicString('abcabc').replace('b', '$`').toString(), 'aacabc')
+        assert.strictEqual(new MagicString('abcabc').replace('b', '$\'').toString(), 'acabccabc')
+      })
+
+      it('leaves group references literal for a string search value', () => {
+        // a string search value has no capture groups of either kind
+        assert.strictEqual(new MagicString('11').replace('1', '$0$1').toString(), '$0$11')
+        assert.strictEqual(new MagicString('abc').replace('b', '$<x>').toString(), 'a$<x>c')
+      })
+
+      it('agrees with String.prototype.replace and replaceAll across the table', () => {
+        const sources = ['abcabc', 'hello world', 'a1b2c3', 'aaa']
+        const patterns: [string, string][] = [
+          ['b', ''],
+          ['b', 'g'],
+          ['(a)(b)', ''],
+          ['(a)(b)', 'g'],
+          ['a(b)?', 'g'],
+          ['(?<first>a)(?<second>b)', 'g'],
+          [String.raw`(\w)(\w+)`, 'g'],
+        ]
+        const replacements = [
+          'X',
+          '$$',
+          '$&',
+          '$`',
+          '$\'',
+          '$0',
+          '$1',
+          '$2',
+          '$3',
+          '$12',
+          '$01',
+          '$<first>',
+          '$<second>',
+          '$<nope>',
+          '$<unclosed',
+          '$',
+          '$z',
+          '$$&',
+          '<$`|$&|$\'>',
+        ]
+
+        for (const source of sources) {
+          for (const [pattern, flags] of patterns) {
+            for (const replacement of replacements) {
+              for (const method of ['replace', 'replaceAll'] as const) {
+                if (method === 'replaceAll' && !flags.includes('g'))
+                  continue
+
+                const label = `${JSON.stringify(source)}.${method}(/${pattern}/${flags}, ${JSON.stringify(replacement)})`
+
+                assert.strictEqual(
+                  new MagicString(source)[method](new RegExp(pattern, flags), replacement).toString(),
+                  source[method](new RegExp(pattern, flags), replacement),
+                  label,
+                )
+              }
+            }
+          }
+        }
+      })
+
+      it('agrees with String.prototype for a string search value', () => {
+        const sources = ['abcabc', 'hello world', 'foo bar foo']
+        const needles = ['b', 'o', 'foo', 'zzz', '']
+        const replacements = ['X', '$$', '$&', '$`', '$\'', '$1', '$0', '$<n>', '$', '[$&]', '$$&']
+
+        for (const source of sources) {
+          for (const needle of needles) {
+            for (const replacement of replacements) {
+              for (const method of ['replace', 'replaceAll'] as const) {
+                const label = `${JSON.stringify(source)}.${method}(${JSON.stringify(needle)}, ${JSON.stringify(replacement)})`
+
+                assert.strictEqual(
+                  new MagicString(source)[method](needle, replacement).toString(),
+                  source[method](needle, replacement),
+                  label,
+                )
+              }
+            }
+          }
+        }
+      })
     })
 
     it('works with global regex replace function', () => {
@@ -2269,6 +2416,27 @@ describe('magicString', () => {
 
       assert.strictEqual(s.toString(), 'abc')
       assert.strictEqual(s.hasChanged(), false)
+    })
+
+    it('expands substitution patterns for every match', () => {
+      assert.strictEqual(
+        new MagicString('a1b2').replaceAll(/(\d)/g, '[$1$&]').toString(),
+        'a[11]b[22]',
+      )
+      assert.strictEqual(new MagicString('foo foo').replaceAll('foo', '$&$&').toString(), 'foofoo foofoo')
+    })
+
+    it('expands substitution patterns at every empty-string match', () => {
+      const code = 'ab'
+
+      assert.strictEqual(
+        new MagicString(code).replaceAll('', '$`').toString(),
+        code.replaceAll('', '$`'),
+      )
+      assert.strictEqual(
+        new MagicString(code).replaceAll('', '<$$>').toString(),
+        code.replaceAll('', '<$$>'),
+      )
     })
   })
 })


### PR DESCRIPTION
Closes #341.

`replace` and `replaceAll` are documented against `String.prototype.replace`, and the substitution
code carries a link to the MDN table of `$` patterns. It implemented three of that table's six
entries, and got one of the three wrong. The full set of divergences, with reproductions, is in
#341; the one that matters most in practice is silent:

```js
new MagicString('ac').replace(/a(b)?/, '[$1]').toString()
// magic-string      '[undefined]c'   <- the text `undefined` in the output
// String.prototype  '[]c'
```

An optional group that happens not to match is ordinary, and nothing is thrown, so `undefined`
simply becomes part of the generated code.

## Mechanism

The old substitution was a single pass of `replacement.replace(/\$(\$|&|\d+)/g, ...)`:

- the group branch returned `match[+i]` guarded only by `num < match.length`. For a group that did
  not participate, `match[n]` is `undefined`, which is returned from the replacer and coerced to the
  string `"undefined"` on concatenation. The same guard admits `i === '0'`, and `match[0]` is the
  whole match, so `$0` expanded to it instead of staying literal.
- `\d+` is greedy, so `$12` was always read as index 12. `String.prototype.replace` prefers the
  two-digit reading only when that group exists and otherwise falls back to one digit, which is why
  `$12` is group 1 followed by `2` when the pattern has a single group.
- ``$` ``, `$'` and `$<name>` are not in the pattern at all, so they were never candidates.
- `_replaceString` and `_replaceAllString` passed the replacement through untouched, so none of the
  table applied to a string search value — including `$$` and `$&`, which do apply there in JS.

Replaced with a scan over the replacement that follows the same rules. A string search value has no
capture groups, so it is handled by the same function with an empty capture list and no named
groups, which is what makes `$n` and `$<name>` correctly stay literal for it while `$$`, `$&`,
``$` `` and `$'` expand.

## Verification

A differential harness against `String.prototype.replace`/`replaceAll` as the reference, over
random sources, patterns (0–3 groups, named groups, optional groups, zero-length matches, both
global and not) and replacement strings assembled from the substitution tokens:

| | comparisons | disagreements |
|---|---|---|
| master (`5473bfb`) | 136,000 | **32,902** |
| this branch | 136,000 | **0** |

Every disagreement on master was one of the cases in #341. 277 tests pass, lint and typecheck clean.

**One existing expectation changed.** `works with global regex replace` asserted

```js
new MagicString('1 2 3 4 a b c').replace(/(\d)/g, 'xx$1$10')
// asserted 'xx1$10 xx2$10 xx3$10 xx4$10 a b c'
```

but `'1 2 3 4 a b c'.replace(/(\d)/g, 'xx$1$10')` is `'xx110 xx220 xx330 xx440 a b c'` — the test
pinned the `$nn` divergence. It now asserts the `String.prototype` result, and compares against it
directly so it cannot drift again. The `replaceAll` counterpart only asserted that `replaceAll`
agrees with `replace`, so it still holds unchanged.

## Performance

The regexp path gets faster, because a per-match `String.prototype.replace` over the replacement is
now a scan that returns immediately when the replacement contains no `$`. On a 400-line input,
median of three runs:

| | master | this branch |
|---|---|---|
| `replaceAll(/const/g, 'let')` | 0.149 ms | 0.133 ms |
| `replaceAll(/(const)/g, '[$1]')` | 0.185 ms | 0.144 ms |
| `replaceAll('const', 'let')` | 0.103 ms | 0.108 ms |

The string path pays one `includes('$')` per match, which is the ~5% on the last row. The
`$`-bearing string cases are slower in absolute terms only because they now perform a substitution
that was previously skipped.

## Not changed here

`_replaceRegexp` always passes `match.groups` as the trailing argument to a replacer function, so a
replacer sees one extra `undefined` argument when the pattern has no named groups, where
`String.prototype.replace` omits it entirely. That is a separate path from the substitution table
and I have left it alone to keep this diff to one concern — happy to follow up if you would like it
fixed too.
