### PR TITLE
fix: only pass the groups object to a replacer when the pattern has named groups

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1219,7 +1219,12 @@ export default class MagicString {
         })
       }
       else {
-        return replacement(match[0], ...match.slice(1), match.index, str, match.groups)
+        // `String.prototype.replace` only passes the named-capture-groups object
+        // when the pattern actually has named groups - passing an `undefined`
+        // there unconditionally shifts the last argument a replacer sees
+        return match.groups === undefined
+          ? replacement(match[0], ...match.slice(1), match.index, str)
+          : replacement(match[0], ...match.slice(1), match.index, str, match.groups)
       }
     }
     const replaceMatch = (match: RegExpMatchArray): void => {

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -2103,6 +2103,42 @@ describe('magicString', () => {
       )
     })
 
+    it('only passes the groups object when the pattern has named groups', () => {
+      const args: any[][] = []
+      const native: any[][] = []
+      const code = 'abc'
+
+      new MagicString(code).replace(/b/g, (...rest: any[]) => {
+        args.push(rest)
+        return 'Z'
+      })
+      code.replace(/b/g, (...rest: any[]) => {
+        native.push(rest)
+        return 'Z'
+      })
+
+      assert.deepEqual(args, native)
+      assert.deepEqual(args, [['b', 1, code]])
+    })
+
+    it('passes the groups object when the pattern has named groups', () => {
+      const args: any[][] = []
+      const native: any[][] = []
+      const code = 'abc'
+
+      new MagicString(code).replace(/(?<mid>b)/g, (...rest: any[]) => {
+        args.push(rest)
+        return 'Z'
+      })
+      code.replace(/(?<mid>b)/g, (...rest: any[]) => {
+        native.push(rest)
+        return 'Z'
+      })
+
+      assert.deepEqual(args, native)
+      assert.deepEqual(args, [['b', 'b', 1, code, { mid: 'b' }]])
+    })
+
     it('should ignore non-changed replacements', () => {
       const code = 'a12bc345#$*%'
       const matched: string[] = []


### PR DESCRIPTION
`_replaceRegexp` passes `match.groups` as the trailing argument to a replacer function on every call:

```js
return replacement(match[0], ...match.slice(1), match.index, str, match.groups)
```

`String.prototype.replace` only passes that argument when the pattern actually contains named capture groups. When it does not, `match.groups` is `undefined` and magic-string hands the replacer one extra argument that the reference implementation never sends.

```js
'abc'.replace(/b/g, (...args) => (console.log(args), 'Z'))
// [ 'b', 1, 'abc' ]

new MagicString('abc').replace(/b/g, (...args) => (console.log(args), 'Z'))
// [ 'b', 1, 'abc', undefined ]
```

Replacers written against the documented signature are affected whenever they read from the end of the argument list rather than a fixed position, which is the usual way to reach the offset or the source string from a variadic replacer:

```js
const replacer = (...args) => {
  const source = args.at(-1)     // the source string natively, `undefined` here
  const offset = args.at(-2)     // the offset natively, the source string here
  // ...
}
```

Replacers with a fixed arity are unaffected, since the extra argument is simply dropped, which is why the existing `replace function offset` test passes either way.

## Fix

Pass the groups object only when the match has one, matching the [documented behaviour](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_a_parameter) the source already links to. Named groups keep working exactly as before.

## Tests

Two tests, both differential against `String.prototype.replace` on the same input, one with a named group and one without. The no-named-group test fails on `master` with the extra `undefined` and passes with the fix; the named-group test guards against over-correcting.

`pnpm run lint`, `pnpm run typecheck` and `pnpm test` (264 tests) all pass locally.

This is the remaining `String.prototype.replace` divergence noted in #340, split out as its own change; the two do not overlap in the diff.
