### PR TITLE
fix: count source appends and prepends in Bundle#length

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -321,7 +321,7 @@ export default class Bundle {
       // mirrors toString(): every source but the first is preceded by a separator
       const separator = source.separator !== undefined ? source.separator : this.separator
 
-      return length + (i > 0 ? separator.length : 0) + source.content.length()
+      return length + (i > 0 ? separator.length : 0) + source.content.toString().length
     }, this.intro.length)
   }
 

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -802,6 +802,16 @@ describe('bundle', () => {
 
       assert.equal(b.length(), b.toString().length)
     })
+
+    it('should count content appended or prepended to a source', () => {
+      const b = new Bundle({ separator: ';' })
+
+      b.addSource(new MagicString('abc').append('X'))
+      b.addSource(new MagicString('def').prepend('Y'))
+
+      assert.equal(b.toString(), 'abcX;Ydef')
+      assert.equal(b.length(), b.toString().length)
+    })
   })
 
   describe('prepend', () => {


### PR DESCRIPTION
`Bundle#length()` is meant to equal `Bundle#toString().length`. Its existing tests assert exactly that for the default separator, a custom separator, a per-source separator, and the intro.

However, it summed each source with `MagicString#length()`, which by design does not count text appended or prepended at the edges of a source. `toString()` renders each source with `source.content.toString()`, so that edge content appeared in the output but was missing from the length.

```js
import MagicString, { Bundle } from 'magic-string';

const b = new Bundle({ separator: ';' });
b.addSource(new MagicString('abc').append('X'));
b.addSource(new MagicString('def').prepend('Y'));

b.toString(); // "abcX;Ydef" (length 9)
b.length();   // 7 before this fix, 9 after
```

The fix measures each source's rendered length (`source.content.toString().length`), mirroring what `toString()` already does per source. I added a test that fails on the old code and passes now; the suite goes from 262 to 263 passing, and `tsc` and `eslint` are clean.
