### PR TITLE
fix: count string-level appends and prepends in isEmpty

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1043,6 +1043,9 @@ export default class MagicString {
    * Returns true if the resulting source is empty (disregarding white space).
    */
   isEmpty(): boolean {
+    // mirrors toString(): the string-level intro and outro bookend the chunks
+    if (this.intro.length && this.intro.trim())
+      return false
     let chunk: Chunk | null = this.firstChunk
     while (chunk) {
       if (
@@ -1054,6 +1057,8 @@ export default class MagicString {
       }
       chunk = chunk.next
     }
+    if (this.outro.length && this.outro.trim())
+      return false
     return true
   }
 

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -1882,6 +1882,22 @@ describe('magicString', () => {
 
       assert.equal(s.isEmpty(), true)
     })
+
+    it('should count content appended or prepended to the string', () => {
+      assert.equal(new MagicString('').append('X').isEmpty(), false)
+      assert.equal(new MagicString('').prepend('Y').isEmpty(), false)
+
+      const s = new MagicString('abc')
+      s.remove(0, 3)
+      s.append('!')
+      assert.equal(s.toString(), '!')
+      assert.equal(s.isEmpty(), false)
+    })
+
+    it('should still disregard whitespace appended or prepended to the string', () => {
+      const s = new MagicString('').prepend('  ').append('   ')
+      assert.equal(s.isEmpty(), true)
+    })
   })
 
   describe('length', () => {


### PR DESCRIPTION
`isEmpty()` is documented, both in the README and in its own JSDoc, as returning true when "the resulting source is empty (disregarding white space)". The resulting source is what `toString()` produces.

However, `isEmpty()` only walked the chunks. It never looked at the string-level `intro` and `outro` that plain `prepend()` and `append()` write to (unlike `prependLeft`/`prependRight`/`appendLeft`/`appendRight`, which write to chunk intro/outro and were already covered). So a source whose only output came from `append()` or `prepend()` was reported as empty even though `toString()` returned that content.

```js
import MagicString from 'magic-string';

const s = new MagicString('').append('X');
s.toString(); // "X"
s.isEmpty();  // true before this fix, false after
```

This is different from `length()`, which is documented and tested to deliberately exclude edge inserts. `isEmpty()` has no such contract: its existing test only ever prepends and appends whitespace, so it never locked the old behaviour, and every other output-facing method (`toString()`, `generateMap()`, `lastChar()`) already accounts for `intro` and `outro`.

The fix adds the two missing checks, mirroring the `toString()` order (intro first, outro last) and reusing the same whitespace-disregarding idiom already used for chunks and in `Bundle#isEmpty`. `Bundle#isEmpty()` delegates to this method per source, so it inherits the fix as well.

I added a test that fails on the old code and passes now, plus a guard test confirming that whitespace-only appends and prepends are still treated as empty. The suite goes from 262 to 264 passing; `tsc` and `eslint` are clean.
