### PR TITLE
fix: return an empty slice when the end index resolves to zero

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1044,7 +1044,7 @@ export default class MagicString {
     let chunk = this.firstChunk
     while (chunk && (chunk.start > start || chunk.end <= start)) {
       // found end chunk before start
-      if (chunk.start < end && chunk.end >= end) {
+      if ((chunk.start < end && chunk.end >= end) || (end === 0 && chunk.start === 0)) {
         return result
       }
 
@@ -1057,6 +1057,12 @@ export default class MagicString {
 
     const startChunk = chunk
     while (chunk) {
+      // for end === 0 the slice ends at the very start of the original, so stop
+      // once the walk reaches the chunk holding that position, taking nothing from it
+      if (end === 0 && chunk.start === 0) {
+        break
+      }
+
       if (chunk.intro && (startChunk !== chunk || chunk.start === start)) {
         result += chunk.intro
       }

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -2294,6 +2294,23 @@ describe('magicString', () => {
 
       assert.equal(s.slice(2, 4), 'cd')
     })
+
+    it('treats an end of zero as an empty upper bound', () => {
+      const s = new MagicString('hello')
+      assert.equal(s.slice(0, 0), '')
+      assert.equal(s.slice(3, 0), '')
+      assert.equal(s.slice(0, -100), '')
+      assert.equal(s.slice(5, 0), '')
+    })
+
+    it('walks moved chunks when the end is zero', () => {
+      const s = new MagicString('abcde')
+      s.move(0, 2, 5)
+      assert.equal(s.toString(), 'cdeab')
+      assert.equal(s.slice(2, 0), 'cde')
+      assert.equal(s.slice(4, 0), 'e')
+      assert.equal(s.slice(1, 0), '')
+    })
   })
 
   describe('snip', () => {


### PR DESCRIPTION
`slice()` finds the chunk holding the end index with `chunk.start < end && chunk.end >= end`. No chunk can satisfy that when `end` is `0` (it would need `chunk.start < 0`), so the loop never stopped at the end and returned everything from `start` onward.

```js
new MagicString('hello').slice(0, 0) // 'hello' before this fix, '' after
new MagicString('hello').slice(3, 0) // 'lo' before, '' after
new MagicString('hello').slice(0, -100) // 'hello' before, '' after (end clamps to 0)
```

`String.prototype.slice` returns `''` for all of these. After the fix, `slice()` mirrors `String.prototype.slice` exactly for an unedited string across every index combination I tested (negative, zero, out of range).

The existing move semantics are preserved: when a moved chunk sits at original position 0, the walk still ends in the right place. For example `new MagicString('abcde').move(0, 2, 5)` produces `'cdeab'`, and `slice(2, 0)` correctly returns `'cde'`.

I added two tests that fail on the current code and pass now. The suite goes from 364 to 366; `tsc` and `eslint` are clean.
