### PR TITLE
fix: carry trimStart and trimEnd into the outro and intro

### DIFF
--- a/src/MagicString.ts
+++ b/src/MagicString.ts
@@ -1248,7 +1248,10 @@ export default class MagicString {
       chunk = chunk.previous
     } while (chunk)
 
-    return false
+    // like Chunk#trimEnd, carry on into the intro once everything after it has
+    // been trimmed away, since the intro is then the end of the string
+    this.intro = this.intro.replace(rx, '')
+    return this.intro.length > 0
   }
 
   /**
@@ -1288,7 +1291,10 @@ export default class MagicString {
       chunk = chunk.next
     } while (chunk)
 
-    return false
+    // like Chunk#trimStart, carry on into the outro once everything before it
+    // has been trimmed away, since the outro is then the start of the string
+    this.outro = this.outro.replace(rx, '')
+    return this.outro.length > 0
   }
 
   /**

--- a/test/Bundle.test.ts
+++ b/test/Bundle.test.ts
@@ -1124,6 +1124,26 @@ describe('bundle', () => {
       b.trimEnd()
       assert.equal(b.toString(), 'abc   ;')
     })
+
+    it('should stop trimStart at a blank source that still has appended content', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('   ').append('X') })
+      b.addSource({ content: new MagicString('  Y') })
+
+      b.trimStart()
+      assert.equal(b.toString(), 'X\n  Y')
+    })
+
+    it('should stop trimEnd at a blank source that still has prepended content', () => {
+      const b = new Bundle()
+
+      b.addSource({ content: new MagicString('Y  ') })
+      b.addSource({ content: new MagicString('   ').prepend('X') })
+
+      b.trimEnd()
+      assert.equal(b.toString(), 'Y  \nX')
+    })
   })
 
   describe('toString', () => {

--- a/test/MagicString.test.ts
+++ b/test/MagicString.test.ts
@@ -2378,6 +2378,20 @@ describe('magicString', () => {
       assert.equal(s.toString(), 'x abc')
     })
 
+    it('should carry trimStart into the global outro when nothing comes before it', () => {
+      const s = new MagicString('   ')
+      s.append(' x ')
+      s.trimStart()
+      assert.equal(s.toString(), 'x ')
+    })
+
+    it('should carry trimEnd into the global intro when nothing comes after it', () => {
+      const s = new MagicString('   ')
+      s.prepend(' x ')
+      s.trimEnd()
+      assert.equal(s.toString(), ' x')
+    })
+
     it('should trim original content', () => {
       assert.equal(new MagicString('   abcdefghijkl   ').trim().toString(), 'abcdefghijkl')
       assert.equal(new MagicString('   abcdefghijkl').trim().toString(), 'abcdefghijkl')


### PR DESCRIPTION
`trimStart()` trims the intro and then walks the chunks, but once the last chunk is done it returns without looking at the outro. `trimEnd()` has the mirror gap: it never reaches the intro. So when everything before the outro (or after the intro) is blank, the whitespace at that end of the string survives:

```js
import MagicString, { Bundle } from 'magic-string'

new MagicString('   ').append(' x ').trimStart().toString() // " x " before this fix, "x " after
new MagicString('   ').prepend(' x ').trimEnd().toString()  // " x " before this fix, " x" after
```

The return value is also wrong in that case: it reports that everything was trimmed away even though the outro or intro still has content. `Bundle` relies on it to decide whether to keep trimming into the next source, so it goes on to strip the separator and the next source too:

```js
const b = new Bundle()
b.addSource(new MagicString('   ').append('X'))
b.addSource(new MagicString('  Y'))
b.toString()             // "   X\n  Y"
b.trimStart().toString() // "XY" before this fix, "X\n  Y" after
```

`trimEnd()` on a bundle does the same from the other side (`"Y  \nX   "` became `"YX"`).

`Chunk#trimStart` already carries on into the chunk's outro once its intro and content are gone, and `Chunk#trimEnd` into its intro. This does the same one level up: after the last chunk, `trimStart()` trims the outro and `trimEnd()` trims the intro, and the return value reports whether anything is left there.

To check the result beyond these cases, I compared `trimStart`, `trimEnd`, `trim` and `trimLines` against plain string trimming of `toString()` on 30,000 random edit sequences for `MagicString` and 30,000 random bundles (whitespace, empty and non-whitespace separators, bundle-level prepend and append). Before the fix there were several thousand mismatches across all four methods on both classes; after it there are none. `lastChar()`, `lastLine()`, `isEmpty()` and `clone()` also stay consistent with `toString()` after trimming.

The four new tests (two for `MagicString`, two for `Bundle`) fail on the old code and pass now. The suite goes from 366 to 370, and `tsc` (both configs) and `eslint` are clean.

CI did not run here: since 77f0e57 the triggers in `test.yml` list only `main`, while this repo's default branch is `master` (they listed both before). I ran the suite, typecheck and lint locally.
